### PR TITLE
Prepare v0.3.0 release (changelog + release process + clean-release fixes)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,13 +29,10 @@ jobs:
       - name: Set up Python (using uv)
         run: uv python install
 
-      - name: Set supply-chain cool-off cutoff
-        # uv's --exclude-newer takes a date, not a relative duration, so compute
-        # "14 days ago" at run time. (Assumes a Linux runner with GNU date.)
-        run: echo "UV_EXCLUDE_NEWER=$(date -u -d '14 days ago' +%Y-%m-%d)" >> "$GITHUB_ENV"
-
       - name: Install all dependencies
-        run: uv sync --all-extras
+        # Install from the committed lockfile so the release is built and tested
+        # against the exact vetted versions (the pyproject cool-off governs upgrades).
+        run: uv sync --all-extras --locked
 
       - name: Run tests
         run: uv run pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,65 @@
+# Changelog
+
+All notable changes to chopdiff are documented here. This project uses
+[semantic versioning](https://semver.org/); while pre-1.0, breaking changes bump the
+**minor** version (see `docs/publishing.md`).
+
+## v0.3.0
+
+This is a cleanup release that hardens the build, makes `TextDoc` source-referenced and
+Markdown-block-aware, and removes the mandatory `tiktoken` (network) dependency. It
+contains several intentional breaking changes for a cleaner API.
+
+### Breaking changes
+
+- **Token counting is now a dependency-free estimate.** The `tiktoken` dependency is
+  removed (along with `requests`/`urllib3` at install time), so chopdiff no longer
+  downloads a tokenizer or needs network access to size or summarize a document.
+  - `TextUnit.tiktokens` is renamed to `TextUnit.tokens` and now returns a heuristic
+    estimate (`chopdiff.util.token_estimate.estimate_tokens`, ~3.8 characters/token,
+    a blend of current OpenAI/Anthropic/Google rules of thumb).
+  - `chopdiff.util.tiktoken_utils` and `tiktoken_len` are removed. Migrate
+    `from chopdiff.util.tiktoken_utils import tiktoken_len` to
+    `from chopdiff.util.token_estimate import estimate_tokens`.
+  - `size_summary()` reports the estimate as `~N tok`.
+  - Exact, provider-keyed token counts (tiktoken/OpenAI, and network-based counters
+    for other providers) are planned as opt-in extras in a future release.
+- **Character offsets are now an `Offsets` record.** `Paragraph.char_offset` and
+  `Sentence.char_offset` (plain ints) are replaced by an `Offsets(doc_offset,
+  block_offset)` record on both:
+  - `doc_offset` is the absolute offset in the document; `block_offset` is relative to
+    the enclosing block (the document for a paragraph, the paragraph for a sentence).
+  - `TextDoc.char_offset_in_doc(index)` is removed; use
+    `doc.get_sent(index).offsets.doc_offset`.
+  - Offsets are now exact references into the unmodified input text (the document is no
+    longer stripped during parsing).
+- **Paragraph splitting recognizes all blank lines.** Paragraphs split on two or more
+  newlines, including blank lines that contain only whitespace; runs of blank lines
+  collapse into a single break. Previously only a literal `\n\n` split.
+- **Removed the unused `chopdiff` console-script entry point.** chopdiff is a library
+  with no CLI; the entry point pointed at a non-existent `main`.
+
+### New features
+
+- **Markdown block-type classification.** `BlockType` (heading, paragraph, list, table,
+  code, blockquote, html, footnote) and `Paragraph.block_type`, classified by parsing
+  each block with flowmark's Markdown (marko) parser. `TextDoc.iter_blocks(include=,
+  exclude=)` and `TextDoc.filtered(include=, exclude=)` iterate or sub-select blocks by
+  type (e.g. process only paragraphs and list items, skipping headings and tables), and
+  aggregate counts such as sentences/words across paragraph blocks.
+- **Exact source references.** Paragraph and sentence `Offsets` round-trip into the
+  original text; `TextDoc` documents a clear contract for offsets and in-place editing.
+
+### Infrastructure
+
+- Supply-chain hardening: a 14-day dependency cool-off (`exclude-newer`), a committed
+  lockfile, frozen `uv sync --locked` installs in CI, and a `pip-audit` gate. See
+  `SUPPLY-CHAIN-SECURITY.md`.
+- Upgraded to the simple-modern-uv template v0.2.26 (Python 3.14 in the CI matrix, uv
+  0.11.12, basedpyright 1.39.3, docs under `docs/`).
+- The release workflow now installs from the committed lockfile (`--locked`) for
+  reproducible release builds.
+
+### Full changelog
+
+https://github.com/jlevy/chopdiff/compare/v0.2.6...v0.3.0

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -112,9 +112,21 @@ Follow this checklist for each new release.
 
    - **Major** (e.g., `v0.6.0` → `v1.0.0`): Breaking changes
 
+   **Pre-1.0 convention:** while the version is still `0.x`, breaking changes bump the
+   **minor** version (e.g. `v0.2.6` → `v0.3.0`) rather than the major version, which is
+   reserved for the first stable `1.0.0`. Breaking changes are still called out
+   explicitly in the changelog and release notes.
+
+5. **Update the changelog:**
+
+   Add a section for the new version to [`CHANGELOG.md`](../CHANGELOG.md), grouped into
+   Breaking changes / New features / Infrastructure (see existing entries). The GitHub
+   release notes for the version should mirror this section. Commit the changelog (via a
+   short "prepare release" PR) so it is on `main` at the tagged commit.
+
 #### Create the Release
 
-5. **Generate release notes content:**
+6. **Generate release notes content:**
 
    Review changes since the last release:
 
@@ -129,7 +141,7 @@ Follow this checklist for each new release.
    git diff ${LAST_TAG}..HEAD
    ```
 
-6. **Create the release with `gh`:**
+7. **Create the release with `gh`:**
 
    ```shell
    NEW_TAG="vX.Y.Z"  # Replace with actual version
@@ -152,7 +164,7 @@ Follow this checklist for each new release.
    Alternatively, use `--generate-notes` for GitHub’s auto-generated notes, or
    `--notes-file FILENAME` to read from a file.
 
-7. **Verify the release published successfully:**
+8. **Verify the release published successfully:**
 
    ```shell
    # Check the release workflow:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,10 +70,6 @@ audit = [
     "pip-audit>=2.7.0",
 ]
 
-[project.scripts]
-# Add script entry points here:
-chopdiff = "chopdiff:main"
-
 
 # ---- Build system ----
 


### PR DESCRIPTION
## Summary

Prepares the **v0.3.0** release: adds a changelog, documents the release process, and makes two clean-release fixes. No library behavior changes (docs + packaging + CI only).

- **`CHANGELOG.md`** — v0.3.0 notes covering everything since v0.2.6 (block types #7, exact offsets + `Offsets` record + blank-line splitting #9, drop-tiktoken/estimate #10, supply-chain hardening + template upgrade #5), grouped into Breaking changes / New features / Infrastructure, with migration notes.
- **`docs/publishing.md`** — adds the changelog step and documents the pre-1.0 convention (breaking changes bump the **minor** version; major is reserved for 1.0.0). The rest of the release runbook (trusted publishing, `gh release create`, notes format) was already there.
- **Removed the broken `chopdiff` console-script entry point** — chopdiff is a library; the entry point pointed at a non-existent `main`, so the installed `chopdiff` command would crash.
- **`publish.yml` now installs from the committed lockfile** (`uv sync --all-extras --locked`) and drops the rolling cool-off env var, matching `ci.yml` so the release is built/tested against the exact vetted versions.

## Why v0.3.0 (minor)
The release has intentional breaking changes (`Offsets` record replacing `char_offset`; `TextUnit.tiktokens` → `tokens`; `tiktoken` removed; paragraph splitting). Pre-1.0, those bump the minor version per the convention now documented in `publishing.md`.

## Release readiness (verified)
- Main is clean: lint passes, **104 tests pass fully offline** (no network needed), `uv build` succeeds.
- Trusted publishing is already configured (prior releases through v0.2.6); `publish.yml` uses OIDC (`uv publish --trusted-publishing always`) — no token needed.
- Dynamic versioning derives the version from the `vX.Y.Z` tag, so tagging `v0.3.0` produces version `0.3.0`.

## Test Plan
- [x] `uv run python devtools/lint.py --check` passes.
- [x] `uv run pytest` — 104 pass, fully offline.
- [x] `uv build` succeeds after removing the entry point.

## Follow-ups (tracked)
- `chopdiff-rz7x`: regenerate the README example transcript for the new `size_summary` format (needs an OpenAI key; it's a captured live-LLM run).
- `chopdiff-rjlc`: exact provider-keyed token counts as opt-in extras.

https://claude.ai/code/session_01XvF7VDdfUaLB3JmftvErw1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvF7VDdfUaLB3JmftvErw1)_