### PR TITLE
feat: doc-model principles, fixes, and golden-document testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,103 +1,129 @@
 # Changelog
 
-All notable changes to chopdiff are documented here. This project uses
-[semantic versioning](https://semver.org/); while pre-1.0, breaking changes bump the
-**minor** version (see `docs/publishing.md`).
+All notable changes to chopdiff are documented here.
+This project uses [semantic versioning](https://semver.org/); while pre-1.0, breaking
+changes bump the **minor** version (see `docs/publishing.md`).
 
 ## Unreleased
 
 Adds the DocGraph node model and its supporting infrastructure: a recursive node table
 with layers, the `base_blocks()` sequential partition, `collect()` query primitive,
-`SpanRef` span-reference type, and the `DocGraph` Pydantic projection
-(schema "DocGraph/v0.1").
+`SpanRef` span-reference type, and the `DocGraph` Pydantic projection (schema
+“DocGraph/v0.1”).
 
 ### New Features
 
 - **Recursive node table with layers.** The canonical node table fully populates
-  container children (blockquotes, list items) and tags each node with its parse
-  `layer` (textual, markdown, document, synthetic). Cross-layer relationships are
-  offset-containment queries over a shared id space.
+  container children (blockquotes, list items) and tags each node with its parse `layer`
+  (textual, markdown, document, synthetic).
+  Cross-layer relationships are offset-containment queries over a shared id space.
 - **`base_blocks()` sequential partition.** A flat, depth-annotated, non-overlapping
-  partition of the document into base blocks. Lists decompose so each list item is its
-  own base block with increasing `depth`; blockquotes stay atomic. Reassembling in order
-  reproduces the document.
-- **`collect()` query primitive.** One general query (`collect(kinds=, where=,
-  recursive=, inline=)`) at document, section, and block scope, superseding
-  `block_type_counts()` convenience accessors.
+  partition of the document into base blocks.
+  Lists decompose so each list item is its own base block with increasing `depth`;
+  blockquotes stay atomic.
+  Reassembling in order reproduces the document.
+- **`collect()` query primitive.** One general query
+  (`collect(kinds=, where=, recursive=, inline=, layer=)`) at document, section, and
+  block scope, superseding `block_type_counts()` convenience accessors.
+  The `layer=` filter scopes a query to one or more parse layers (default: all layers),
+  since the same span can appear as nodes in several layers.
 - **`SpanRef` span-reference type.** Quote-canonical, offset-hinted span references for
   durable annotation anchoring (exact fast path within a parse, fuzzy re-anchor across
   edits).
 - **`DocGraph` Pydantic projection.** `TextDoc.graph(include=, detail=)` builds a
-  serialized, language-neutral JSON contract (schema "DocGraph/v0.1") with composable
+  serialized, language-neutral JSON contract (schema “DocGraph/v0.1”) with composable
   `Layer` and `Detail` axes.
+- **`TextDoc.base_blocks()` method.** A thin method over the `base_blocks` free
+  function, so the sequential partition has the same ergonomic surface as `blocks()`.
+
+### Fixes
+
+- **`base_blocks()` complete-cover fix.** Content following (or between) a nested
+  sublist inside a list item was dropped from the partition; the partition is now a
+  complete cover again (verified by a cover-invariant test over all non-whitespace
+  source).
+- **Structural-parse memoization.** `TextDoc.blocks()` is now cached on the immutable
+  `source_text`, and `Section.blocks()` / `Section.links()` slice that single cached
+  parse instead of re-parsing the whole document per section (a TOC walk was quadratic).
+
+### Documentation
+
+- **Grounded design principles.** `docs/textdoc-spec.md` now leads with an explicit,
+  three-tier principle set (P1–P18) and a pitfalls/decisions note; the goals cite the
+  principles they realize.
+  The canonical substrate is stated as the source text + offset space, with the node
+  table as one projection (not a rival store).
 
 ### Dependencies
 
 - New runtime dependency: `pydantic>=2.13.4` (brings `annotated-types`, `pydantic-core`,
-  `typing-inspection` as transitive dependencies). Required for the `DocGraph` schema.
+  `typing-inspection` as transitive dependencies).
+  Required for the `DocGraph` schema.
 
 ### Compatibility
 
-- **Additive at the API surface.** The DocGraph work adds public names
-  (`base_blocks`, `collect`, `SpanRef`, `DocGraph`, `NodeModel`, `Node`, `NodeTable`,
-  `NodeKind`, `Layer`, `Detail`, `Views`, `build_doc_graph`, …) without removing or
-  renaming any existing export. `Section.block_type_counts()` /
-  `TextDoc.block_type_counts()` are retained; `collect()` is the preferred general
-  query, not a replacement.
+- **Additive at the API surface.** The DocGraph work adds public names (`base_blocks`,
+  `collect`, `SpanRef`, `DocGraph`, `NodeModel`, `Node`, `NodeTable`, `NodeKind`,
+  `Layer`, `Detail`, `Views`, `build_doc_graph`, …) without removing or renaming any
+  existing export. `Section.block_type_counts()` / `TextDoc.block_type_counts()` are
+  retained; `collect()` is the preferred general query, not a replacement.
 - **Net release vs. v0.3.0.** Taken together with v0.4.0 (below), the upcoming release
-  removes no public symbol present in v0.3.0; every new capability is reached through new
-  methods, types, and exports. The only behavior changes an existing caller can observe
-  are the two noted under v0.4.0: `BlockType.list` is now bullet-only, and default
-  sentence splitting is now span-aware (boundaries may differ; see below).
+  removes no public symbol present in v0.3.0; every new capability is reached through
+  new methods, types, and exports.
+  The only behavior changes an existing caller can observe are the two noted under
+  v0.4.0: `BlockType.list` is now bullet-only, and default sentence splitting is now
+  span-aware (boundaries may differ; see below).
 
 ## v0.4.0
 
 Makes `TextDoc` block-aware end to end: an exact-span structural block tree, a section
-hierarchy with rolled-up stats, inline-link rollups, and link-aware sentence spans. The
-structural view is the canonical normalized form, with every other view (sections,
-block-type slices, tallies) derived from it: no stored counts. Block boundaries and
-spans now come straight from flowmark's parser, so chopdiff carries no Markdown
-block-detection regex of its own.
+hierarchy with rolled-up stats, inline-link rollups, and link-aware sentence spans.
+The structural view is the canonical normalized form, with every other view (sections,
+block-type slices, tallies) derived from it: no stored counts.
+Block boundaries and spans now come straight from flowmark’s parser, so chopdiff carries
+no Markdown block-detection regex of its own.
 
 ### Breaking Changes
 
 - **`BlockType.list` is now bullet-only; ordered lists are `BlockType.ordered_list`.**
-  Ordered-ness is carried from marko's `List.ordered`. Callers that matched
+  Ordered-ness is carried from marko’s `List.ordered`. Callers that matched
   `BlockType.list` to cover *both* list kinds now miss ordered lists; match
   `{BlockType.list, BlockType.ordered_list}` for either.
 - **Default sentence splitting is now span-aware.** `TextDoc.from_text()` with the
   default splitter now routes through `flowmark.atomic_spans.split_sentences_with_spans`
   instead of calling `split_sentences_regex` directly, so sentences never bisect a link,
-  code span, or autolink. Sentence boundaries can therefore differ from v0.3.0 for text
-  containing those constructs. `default_sentence_splitter` is unchanged and passing an
-  explicit splitter preserves the previous behavior.
+  code span, or autolink.
+  Sentence boundaries can therefore differ from v0.3.0 for text containing those
+  constructs. `default_sentence_splitter` is unchanged and passing an explicit splitter
+  preserves the previous behavior.
 
 ### New Features
 
 - **Opt-in structural block tree with exact spans.** `TextDoc.blocks()` returns a
   `Block(type, span, children, tight)` tree whose boundaries and `[start, end)` spans
-  come directly from flowmark's parser (marko's own source positions), so a fenced code
+  come directly from flowmark’s parser (marko’s own source positions), so a fenced code
   block stays whole through internal blank lines and a list always decomposes into
-  `list_item`s with nested sublists. The tree is **density-invariant**: tight and loose
-  spacing of the same list produce identical block/item counts; `Block.tight` records
-  the CommonMark spacing.
+  `list_item`s with nested sublists.
+  The tree is **density-invariant**: tight and loose spacing of the same list produce
+  identical block/item counts; `Block.tight` records the CommonMark spacing.
 - **Per-section structure and tallies.** `Section.blocks()` scopes the structural tree
-  to a section's own content (document-absolute spans), and `Section.block_type_counts()`
-  / `TextDoc.block_type_counts()` give derived `Counter[BlockType]` tallies over the live
-  tree (no stored counts). `Section.content` holds the section's own paragraphs
-  (renamed from `Section.blocks`, which is now the structural method).
+  to a section’s own content (document-absolute spans), and
+  `Section.block_type_counts()` / `TextDoc.block_type_counts()` give derived
+  `Counter[BlockType]` tallies over the live tree (no stored counts).
+  `Section.content` holds the section’s own paragraphs (renamed from `Section.blocks`,
+  which is now the structural method).
 - **Sections, TOC, and rolled-up size stats.** `TextDoc.sections()` returns a tree of
   `Section`s over the heading hierarchy; `TextDoc.toc()` returns a flat
-  `(level, title, span)` list. `Section.size(unit, subtree=True|False)`,
-  `Section.size_summary()`, and `TextDoc.section_size_tree(units=…)` roll up sizes per
-  section in any `TextUnit`.
+  `(level, title, span)` list.
+  `Section.size(unit, subtree=True|False)`, `Section.size_summary()`, and
+  `TextDoc.section_size_tree(units=…)` roll up sizes per section in any `TextUnit`.
 - **Exact `[start, end)` spans on paragraphs and sentences.** Every `Paragraph` and
   `Sentence` exposes a document-relative `span`; `TextDoc.source_text` is retained so
-  each unit's `original_text` round-trips into the source. `TextDoc.block_at_offset(o)`
-  and `sentence_at_offset(o)` invert spans.
+  each unit’s `original_text` round-trips into the source.
+  `TextDoc.block_at_offset(o)` and `sentence_at_offset(o)` invert spans.
 - **Inline-link rollups and link-aware sentence spans.** `Link(text, url, title, span)`
   via `Paragraph.links()`, `Section.links()`, and `TextDoc.links()`—identity from
-  flowmark's `extract_links` (reference links resolve across the whole document), spans
+  flowmark’s `extract_links` (reference links resolve across the whole document), spans
   recovered from `iter_atomic_spans`. The default sentence splitter is now
   `flowmark.atomic_spans.split_sentences_with_spans`, so sentence spans are exact for
   all content and never bisect a link, code span, or autolink.
@@ -107,13 +133,13 @@ block-detection regex of its own.
 
 ### Internal
 
-- **Dropped chopdiff's regex block scanner.** `TextDoc.blocks()` and
-  `Paragraph.block_type` now walk flowmark's annotated parse tree and map marko classes
+- **Dropped chopdiff’s regex block scanner.** `TextDoc.blocks()` and
+  `Paragraph.block_type` now walk flowmark’s annotated parse tree and map marko classes
   to `BlockType` through a single table; the per-line regex scanner, `classify_block`,
-  and the cached `markdown_parser` singleton are gone (net negative code). Because
-  chopdiff no longer makes block-boundary decisions, two earlier bugs are fixed by
-  construction: reference links resolve across block boundaries, and adjacent blocks with
-  no blank line between them split correctly.
+  and the cached `markdown_parser` singleton are gone (net negative code).
+  Because chopdiff no longer makes block-boundary decisions, two earlier bugs are fixed
+  by construction: reference links resolve across block boundaries, and adjacent blocks
+  with no blank line between them split correctly.
 
 ### Dependencies
 
@@ -129,8 +155,8 @@ https://github.com/jlevy/chopdiff/compare/v0.3.0...v0.4.0
 ## v0.3.0
 
 This is a cleanup release that hardens the build, makes `TextDoc` source-referenced and
-Markdown-block-aware, and removes the mandatory `tiktoken` (network) dependency. It
-contains several intentional breaking changes for a cleaner API.
+Markdown-block-aware, and removes the mandatory `tiktoken` (network) dependency.
+It contains several intentional breaking changes for a cleaner API.
 
 ### Breaking Changes
 
@@ -138,17 +164,17 @@ contains several intentional breaking changes for a cleaner API.
   removed (along with `requests`/`urllib3` at install time), so chopdiff no longer
   downloads a tokenizer or needs network access to size or summarize a document.
   - `TextUnit.tiktokens` is renamed to `TextUnit.tokens` and now returns a heuristic
-    estimate (`chopdiff.util.token_estimate.estimate_tokens`, ~3.8 characters/token,
-    a blend of current OpenAI/Anthropic/Google rules of thumb).
-  - `chopdiff.util.tiktoken_utils` and `tiktoken_len` are removed. Migrate
-    `from chopdiff.util.tiktoken_utils import tiktoken_len` to
+    estimate (`chopdiff.util.token_estimate.estimate_tokens`, ~3.8 characters/token, a
+    blend of current OpenAI/Anthropic/Google rules of thumb).
+  - `chopdiff.util.tiktoken_utils` and `tiktoken_len` are removed.
+    Migrate `from chopdiff.util.tiktoken_utils import tiktoken_len` to
     `from chopdiff.util.token_estimate import estimate_tokens`.
   - `size_summary()` reports the estimate as `~N tok`.
-  - Exact, provider-keyed token counts (tiktoken/OpenAI, and network-based counters
-    for other providers) are planned as opt-in extras in a future release.
+  - Exact, provider-keyed token counts (tiktoken/OpenAI, and network-based counters for
+    other providers) are planned as opt-in extras in a future release.
 - **Character offsets are now an `Offsets` record.** `Paragraph.char_offset` and
-  `Sentence.char_offset` (plain ints) are replaced by an `Offsets(doc_offset,
-  block_offset)` record on both:
+  `Sentence.char_offset` (plain ints) are replaced by an
+  `Offsets(doc_offset, block_offset)` record on both:
   - `doc_offset` is the absolute offset in the document; `block_offset` is relative to
     the enclosing block (the document for a paragraph, the paragraph for a sentence).
   - `TextDoc.char_offset_in_doc(index)` is removed; use
@@ -157,7 +183,8 @@ contains several intentional breaking changes for a cleaner API.
     longer stripped during parsing).
 - **Paragraph splitting recognizes all blank lines.** Paragraphs split on two or more
   newlines, including blank lines that contain only whitespace; runs of blank lines
-  collapse into a single break. Previously only a literal `\n\n` split.
+  collapse into a single break.
+  Previously only a literal `\n\n` split.
 - **Removed the unused `chopdiff` console-script entry point.** chopdiff is a library
   with no CLI; the entry point pointed at a non-existent `main`.
 
@@ -165,18 +192,19 @@ contains several intentional breaking changes for a cleaner API.
 
 - **Markdown block-type classification.** `BlockType` (heading, paragraph, list, table,
   code, blockquote, html, footnote) and `Paragraph.block_type`, classified by parsing
-  each block with flowmark's Markdown (marko) parser. `TextDoc.iter_blocks(include=,
-  exclude=)` and `TextDoc.filtered(include=, exclude=)` iterate or sub-select blocks by
-  type (e.g. process only paragraphs and list items, skipping headings and tables), and
-  aggregate counts such as sentences/words across paragraph blocks.
+  each block with flowmark’s Markdown (marko) parser.
+  `TextDoc.iter_blocks(include=, exclude=)` and `TextDoc.filtered(include=, exclude=)`
+  iterate or sub-select blocks by type (e.g. process only paragraphs and list items,
+  skipping headings and tables), and aggregate counts such as sentences/words across
+  paragraph blocks.
 - **Exact source references.** Paragraph and sentence `Offsets` round-trip into the
   original text; `TextDoc` documents a clear contract for offsets and in-place editing.
 
 ### Infrastructure
 
 - Supply-chain hardening: a 14-day dependency cool-off (`exclude-newer`), a committed
-  lockfile, frozen `uv sync --locked` installs in CI, and a `pip-audit` gate. See
-  `SUPPLY-CHAIN-SECURITY.md`.
+  lockfile, frozen `uv sync --locked` installs in CI, and a `pip-audit` gate.
+  See `SUPPLY-CHAIN-SECURITY.md`.
 - Upgraded to the simple-modern-uv template v0.2.26 (Python 3.14 in the CI matrix, uv
   0.11.12, basedpyright 1.39.3, docs under `docs/`).
 - The release workflow now installs from the committed lockfile (`--locked`) for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ with layers, the `base_blocks()` sequential partition, `collect()` query primiti
   `Layer` and `Detail` axes.
 - **`TextDoc.base_blocks()` method.** A thin method over the `base_blocks` free
   function, so the sequential partition has the same ergonomic surface as `blocks()`.
+- **Reusable debug dumper (`chopdiff.docs.debug`).** `doc_report`, `doc_graph_yaml`, and
+  `dump_views` turn any document into clean, deterministic standard-format views (a
+  multi-view report, the DocGraph, the reassembled source) for REPL/script debugging and
+  golden testing.
+- **`DocGraph.to_yaml()`.** A clean, deterministic YAML serialization of the projection
+  alongside the existing JSON (block style, `|` block scalars, `None`/empty suppressed).
 
 ### Fixes
 
@@ -59,6 +65,9 @@ with layers, the `base_blocks()` sequential partition, `collect()` query primiti
 - New runtime dependency: `pydantic>=2.13.4` (brings `annotated-types`, `pydantic-core`,
   `typing-inspection` as transitive dependencies).
   Required for the `DocGraph` schema.
+- New runtime dependency: `frontmatter-format>=0.3.0` (first-party; brings
+  `ruamel-yaml`). Used for clean deterministic YAML (`DocGraph.to_yaml`, the debug
+  dumper) and the Markdown-with-frontmatter golden-test corpus.
 
 ### Compatibility
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,12 @@ with layers, the `base_blocks()` sequential partition, `collect()` query primiti
   (textual, markdown, document, synthetic).
   Cross-layer relationships are offset-containment queries over a shared id space.
 - **`base_blocks()` sequential partition.** A flat, depth-annotated, non-overlapping
-  partition of the document into base blocks.
-  Lists decompose so each list item is its own base block with increasing `depth`;
-  blockquotes stay atomic.
-  Reassembling in order reproduces the document.
+  partition whose spans cover every non-whitespace character exactly once.
+  Lists decompose so each list item is its own base block with increasing `depth`
+  (list-item continuation content keeps its own real type, e.g. `paragraph`, not
+  `list_item`); blockquotes stay atomic.
+  Exact source reconstruction is via each block’s `source_span` (not by concatenating
+  block text).
 - **`collect()` query primitive.** One general query
   (`collect(kinds=, where=, recursive=, inline=, layer=)`) at document, section, and
   block scope, superseding `block_type_counts()` convenience accessors.

--- a/docs/project/specs/active/plan-2026-05-31-doc-model-refinements.md
+++ b/docs/project/specs/active/plan-2026-05-31-doc-model-refinements.md
@@ -4,7 +4,7 @@
 
 **Author:** Joshua Levy
 
-**Status:** Draft
+**Status:** Implemented
 
 ## Overview
 
@@ -175,50 +175,50 @@ To be captured as a short “Pitfalls and decisions” note in the spec:
 Documentation-only; no code behavior change.
 Lands the grounded principles and removes every drift the review found.
 
-- [ ] Add a “Principles” section (Tier 1–3, P1–P18) to `docs/textdoc-spec.md` ahead of
+- [x] Add a “Principles” section (Tier 1–3, P1–P18) to `docs/textdoc-spec.md` ahead of
   §2, and cross-reference the existing goals to the principle each derives from.
-- [ ] Add the “Pitfalls and decisions” note (list above) to the spec.
-- [ ] Correct §3 wording: state that the shared offset space is the canonical substrate
+- [x] Add the “Pitfalls and decisions” note (list above) to the spec.
+- [x] Correct §3 wording: state that the shared offset space is the canonical substrate
   and the node table is a (cached) projection that gathers layers into one id space —
   drop the claim that views currently project from it (or scope it to the target state,
   clearly labeled).
-- [ ] Correct §6: `base_blocks` is a free function returning `list[BaseBlock]` (Block +
+- [x] Correct §6: `base_blocks` is a free function returning `list[BaseBlock]` (Block +
   depth), not `TextDoc.base_blocks() -> list[Block]`; note the `base_blocks.py` /
   `block_tree.py` split.
-- [ ] Correct §6 caching language for `blocks()` to match Phase 2 (mark as the intended
+- [x] Correct §6 caching language for `blocks()` to match Phase 2 (mark as the intended
   state and link to the bead).
-- [ ] Update `CHANGELOG.md` (Unreleased) to note the principles section and the fixes.
+- [x] Update `CHANGELOG.md` (Unreleased) to note the principles section and the fixes.
 
 ### Phase 2: Obvious code fixes
 
 Unambiguous correctness and performance defects.
 
-- [ ] Fix `base_blocks()` so a list item with content after (or between) nested sublists
+- [x] Fix `base_blocks()` so a list item with content after (or between) nested sublists
   is fully covered: emit the item’s interstitial and trailing content as base blocks at
   the item’s depth, preserving order and non-overlap.
-- [ ] Add a cover-invariant test to `tests/docs/test_base_blocks.py` that fails before
+- [x] Add a cover-invariant test to `tests/docs/test_base_blocks.py` that fails before
   the fix (trailing-paragraph-after-sublist case, plus content between two sublists),
   asserting the union of base-block spans covers all non-whitespace source.
-- [ ] Memoize the structural block tree on the immutable `source_text` (cache
+- [x] Memoize the structural block tree on the immutable `source_text` (cache
   `blocks()`), and make `Section.blocks()` / `Section.links()` slice the cached
   whole-document parse instead of re-parsing per section.
-- [ ] Verify `make lint` and `make test` are clean.
+- [x] Verify `make lint` and `make test` are clean.
 
 ### Phase 3: Principle-alignment improvements
 
 Design changes that close the gap to P12/P3/P4. Each cites its principle.
 
-- [ ] **(P3/P4/P12)** Add `layer: set[Layer] | None = None` (default all layers) to
+- [x] **(P3/P4/P12)** Add `layer: set[Layer] | None = None` (default all layers) to
   `collect()` and `TextDoc.collect()`; document that the same logical unit appears per
   layer and that callers scope by layer.
   Add tests showing a paragraph query returns one node per requested layer (no
   cross-layer duplicates) and that default-all still returns every layer.
-- [ ] **(P5)** Add `TextDoc.base_blocks()` wrapping the free function so spec and code
+- [x] **(P5)** Add `TextDoc.base_blocks()` wrapping the free function so spec and code
   agree (per Resolved Decisions).
-- [ ] **(P1/P12)** Land the offset-space-canonical framing: §3 wording (Phase 1) plus
+- [x] **(P1/P12)** Land the offset-space-canonical framing: §3 wording (Phase 1) plus
   `node_table()` deriving from the memoized parse (Phase 2). No view-from-node-table
   refactor (see Resolved Decisions); nothing left open here.
-- [ ] Minor: make `collect()` sort `None`-span nodes deterministically (not at offset
+- [x] Minor: make `collect()` sort `None`-span nodes deterministically (not at offset
   0); remove or justify the dead first-pass image branch in `_build_inline_nodes`.
 
 ## Testing Strategy

--- a/docs/project/specs/active/plan-2026-05-31-doc-model-refinements.md
+++ b/docs/project/specs/active/plan-2026-05-31-doc-model-refinements.md
@@ -1,0 +1,282 @@
+# Feature: Document-Model Documentation and Design Refinements
+
+**Date:** 2026-05-31 (last updated 2026-05-31)
+
+**Author:** Joshua Levy
+
+**Status:** Draft
+
+## Overview
+
+The DocGraph node model shipped (PR #12) on top of the v0.4.0 block-aware `TextDoc`. A
+design review of the merged result found the architecture sound but the *stated
+principles* under-articulated, the spec drifted from the code in a few places, and two
+verified correctness/performance defects.
+This plan refines the design so it is grounded in an explicit, layered set of
+principles, fixes the obvious documentation and code defects first, and then maps the
+deeper work that brings the implementation into alignment with those principles.
+
+The work is sequenced so the safe, high-value changes land first (principles and
+documentation, then obvious code fixes), and the design-alignment changes that need more
+thought come last, each traceable to the principle it serves.
+
+## Goals
+
+- **Make the principles explicit and grounded.** Restate the design as a small spine of
+  foundational principles with the capability and pragmatic principles derived from
+  them, so every later decision cites a principle.
+- **Remove documentation drift.** Bring `docs/textdoc-spec.md` into exact agreement with
+  the implemented API (method vs.
+  free function, return types, caching claims, the true canonical substrate).
+- **Fix the obvious defects.** The `base_blocks()` cover-invariant bug and the
+  `blocks()`/per-section re-parse cost are clear correctness/performance issues with no
+  design ambiguity.
+- **Map the alignment work.** Specify the design changes (layer-aware `collect()`, views
+  that project from the node table, `base_blocks` surface) that close the gap between
+  the “node table is canonical” claim and the current multi-parse reality.
+
+## Non-Goals
+
+- No new layers (synthetic, annotation, layout, provenance) — those remain later phases
+  of the unified-document-model plan.
+- No change to the `DocGraph/v0.1` serialized schema shape beyond what a fixed defect
+  requires.
+- No new external dependencies.
+- No reopening of settled decision records (DR-1..DR-6); this plan refines their
+  *expression* and *implementation fidelity*, not the decisions.
+
+## Background
+
+Context for the review and its findings:
+
+- The model spans `node.py`, `node_table.py`, `block_tree.py`, `base_blocks.py`,
+  `collect.py`, `span_ref.py`, `doc_graph.py`, `render.py`, and the heavily extended
+  `text_doc.py`, with `docs/textdoc-spec.md` as the design of record.
+- The spec’s §2 Goals reads as a flat list.
+  The review found a **spine** of five foundational principles (shared offset space;
+  source-canonical projection; layered parsing with offset-containment; mechanism over
+  menu; model ≠ format ≠ implementation) that the other ten capability/pragmatic goals
+  are consequences of.
+  Naming the spine is the “grounding” this plan adds.
+- Two defects were reproduced directly:
+  - `base_blocks()` drops content that follows a nested sublist inside a list item
+    (verified: the trailing paragraph of a list item is absent from the partition),
+    violating the complete-cover / reassembly invariant.
+  - `TextDoc.blocks()` is documented “lazy, cached” but re-parses on every call
+    (`blocks() is blocks()` is `False`); `Section.blocks()` and `Section.links()` each
+    re-parse the whole document per section, making a TOC walk quadratic.
+    Only `node_table()` is actually cached.
+- One honesty gap: the spec says the node table is *the* canonical store with all views
+  as O(n) projections sharing its ids, but in code the node table is *assembled from*
+  several independent parses, and `blocks()`/`sections()`/`links()`/`base_blocks()` do
+  not project from it.
+  The true unifying substrate is the shared `source_text` + code- point offset space.
+- One API gap: `collect()` has no `layer=` filter, so kind-filtered queries return
+  cross-layer duplicates (a paragraph appears as both a `markdown` and a `textual` node;
+  a heading line also appears as a `textual` paragraph).
+  This undercuts the “clean derived views” and “mechanism over menu” principles.
+
+## Design
+
+### The principles (the deliverable of Phase 1)
+
+A three-tier set, to be added to `docs/textdoc-spec.md` as a new “Principles” section
+ahead of §2 and cross-referenced from the goals.
+
+**Tier 1 — Foundational (the spine):**
+
+- **P1. One immutable source, one shared offset space, is the canonical substrate.**
+  Every structure aligns to `source_text` by exact `[start, end)` in Unicode code
+  points.
+- **P2. Source is canonical; every structural model is a derived, re-derivable
+  projection.** Edits go through the source/editing view and re-derive (DR-1/DR-2).
+- **P3. Layered parsing; cross-layer relationships are offset-containment queries, not
+  stored edges.** Independent parse dimensions (textual / markdown / document /
+  synthetic) tagged by `layer`; containment, not persisted edges.
+- **P4. Mechanism over menu.** One query primitive (`collect()`), two composable
+  serialization axes (`include` / `detail`); no blessed per-kind rollups (DR-4/DR-5).
+- **P5. Model ≠ format ≠ implementation.** A language-neutral JSON contract (Pydantic-
+  authored, DR-3); Python now, Rust/TS later, implement one contract.
+
+**Tier 2 — Representation:**
+
+- **P6. Exact ground-truth references** (`source_text[s:e] == original_text`).
+- **P7. Faithful, complete Markdown structure** (all modern block + inline kinds; one
+  top-level type per block; recursive fully-populated nesting; bullet vs.
+  ordered distinct).
+- **P8. Textual structure with clean round-trip** (paragraphs/sentences/wordtoks editing
+  view; `reassemble()`).
+- **P9. Document structure** (heading hierarchy / sections / TOC; section containment).
+- **P10. Synthetic tag structure** (marker-tag whitelist as a first-class layer).
+- **P11. Clean whole-tree round-trip editing** — Markdown-object-exact after arbitrary
+  edits, byte-exact when Flowmark-normalized or reconstructed from retained offsets.
+
+**Tier 3 — Pragmatics:**
+
+- **P12. Single canonical form, derived views, no stored counts.**
+- **P13. Complete base-block partition** (ordered, non-overlapping, full cover, depth-
+  annotated).
+- **P14. Serializable projections** (full parse or any slice to language-neutral JSON).
+- **P15. Parse cost ≈ one Markdown parse; expensive views are lazy.**
+- **P16. Approximation where cheap and sufficient** (regex sentence segmentation,
+  heuristic token sizing); exactness reserved for offsets/spans.
+- **P17. Graceful tolerance of malformed input** (never throw on bad Markdown).
+- **P18. Additive evolution** (existing diff/window/wordtok behavior preserved).
+
+### Pitfalls and decisions to record
+
+To be captured as a short “Pitfalls and decisions” note in the spec:
+
+- Tight vs. loose lists are structurally identical; density is `Block.tight` metadata
+  only and never enters a tally.
+- Base blocks decompose lists recursively to `item_partition_depth` (default 6);
+  blockquotes are always atomic.
+- Fast/approximate sentence segmentation is accepted (no Spacy dependency); offsets stay
+  exact via the span-aware splitter.
+- Fast/approximate token sizing is accepted (`estimate_tokens` heuristic; not provider-
+  keyed).
+- The shared offset space — not the node table — is the true canonical substrate.
+- Cross-layer queries are offset-containment; the same logical paragraph appears as
+  distinct nodes in distinct layers, so queries must be layer-aware.
+- Reference links and other unlocatable identities carry `span=None` and are excluded
+  from offset-scoped rollups.
+- Offsets are Unicode code points; byte/UTF-16 are derived on demand, never canonical.
+- Round-trip is Markdown-object-exact, not byte-exact, except via retained offsets or
+  after Flowmark normalization (two distinct equivalence levels; state both).
+
+### Components
+
+| Area | Files |
+| --- | --- |
+| Spec / principles | `docs/textdoc-spec.md` |
+| Base-block cover fix | `src/chopdiff/docs/base_blocks.py`, `tests/docs/test_base_blocks.py` |
+| Caching / parse cost | `src/chopdiff/docs/text_doc.py` |
+| Layer-aware `collect()` | `src/chopdiff/docs/collect.py`, `src/chopdiff/docs/text_doc.py`, tests |
+| Node-table-as-projection | `src/chopdiff/docs/node_table.py`, `src/chopdiff/docs/text_doc.py` |
+
+### API Changes
+
+- **Additive:** `collect(..., layer: set[Layer] | None = None)` on both the free
+  function and `TextDoc.collect()`; default `None` = all layers (see Resolved
+  Decisions).
+- **Additive:** `TextDoc.base_blocks(*, item_partition_depth=6) -> list[BaseBlock]` as a
+  method wrapping the free function, so the ergonomic surface matches `blocks()` and the
+  spec describes a real method.
+- **Behavioral fix (not a surface change):** `base_blocks()` now covers all list-item
+  content; callers relying on the (buggy) partial cover would see additional base
+  blocks.
+- **Performance fix (not a surface change):** `blocks()` and per-section structural
+  slices become memoized; results are unchanged.
+
+## Implementation Plan
+
+### Phase 1: Principles and documentation (do first)
+
+Documentation-only; no code behavior change.
+Lands the grounded principles and removes every drift the review found.
+
+- [ ] Add a “Principles” section (Tier 1–3, P1–P18) to `docs/textdoc-spec.md` ahead of
+  §2, and cross-reference the existing goals to the principle each derives from.
+- [ ] Add the “Pitfalls and decisions” note (list above) to the spec.
+- [ ] Correct §3 wording: state that the shared offset space is the canonical substrate
+  and the node table is a (cached) projection that gathers layers into one id space —
+  drop the claim that views currently project from it (or scope it to the target state,
+  clearly labeled).
+- [ ] Correct §6: `base_blocks` is a free function returning `list[BaseBlock]` (Block +
+  depth), not `TextDoc.base_blocks() -> list[Block]`; note the `base_blocks.py` /
+  `block_tree.py` split.
+- [ ] Correct §6 caching language for `blocks()` to match Phase 2 (mark as the intended
+  state and link to the bead).
+- [ ] Update `CHANGELOG.md` (Unreleased) to note the principles section and the fixes.
+
+### Phase 2: Obvious code fixes
+
+Unambiguous correctness and performance defects.
+
+- [ ] Fix `base_blocks()` so a list item with content after (or between) nested sublists
+  is fully covered: emit the item’s interstitial and trailing content as base blocks at
+  the item’s depth, preserving order and non-overlap.
+- [ ] Add a cover-invariant test to `tests/docs/test_base_blocks.py` that fails before
+  the fix (trailing-paragraph-after-sublist case, plus content between two sublists),
+  asserting the union of base-block spans covers all non-whitespace source.
+- [ ] Memoize the structural block tree on the immutable `source_text` (cache
+  `blocks()`), and make `Section.blocks()` / `Section.links()` slice the cached
+  whole-document parse instead of re-parsing per section.
+- [ ] Verify `make lint` and `make test` are clean.
+
+### Phase 3: Principle-alignment improvements
+
+Design changes that close the gap to P12/P3/P4. Each cites its principle.
+
+- [ ] **(P3/P4/P12)** Add `layer: set[Layer] | None = None` (default all layers) to
+  `collect()` and `TextDoc.collect()`; document that the same logical unit appears per
+  layer and that callers scope by layer.
+  Add tests showing a paragraph query returns one node per requested layer (no
+  cross-layer duplicates) and that default-all still returns every layer.
+- [ ] **(P5)** Add `TextDoc.base_blocks()` wrapping the free function so spec and code
+  agree (per Resolved Decisions).
+- [ ] **(P1/P12)** Land the offset-space-canonical framing: §3 wording (Phase 1) plus
+  `node_table()` deriving from the memoized parse (Phase 2). No view-from-node-table
+  refactor (see Resolved Decisions); nothing left open here.
+- [ ] Minor: make `collect()` sort `None`-span nodes deterministically (not at offset
+  0); remove or justify the dead first-pass image branch in `_build_inline_nodes`.
+
+## Testing Strategy
+
+- Phase 2 is test-first: the cover-invariant test must fail before the fix and pass
+  after. A property-style check (union of base-block spans covers all non-whitespace
+  source, spans non-overlapping and ordered) guards the invariant generally.
+- Caching changes are behavior-preserving: assert identical results before/after and
+  assert the cached object identity / single parse call (e.g. via a call counter or
+  `is`).
+- Phase 3 `collect(layer=)` gets tests asserting no cross-layer duplicates for shared
+  kinds (`paragraph`) and correct single-layer results.
+- `make lint` and `make test` clean after each phase.
+
+## Rollout Plan
+
+- All changes are additive or behavior-preserving except the `base_blocks()` cover fix,
+  which corrects a defect; note it in the changelog under fixes.
+- Land per phase; each phase is independently shippable.
+  Beads sequence the phases with dependencies (Phase 2 and 3 code beads depend on the
+  Phase 1 spec beads only where the spec must describe the intended state first).
+
+## Resolved Decisions
+
+Both prior open questions are resolved; the principle and the simplest/most-flexible
+choice are recorded here.
+
+- **`collect()` layer handling — `layer: set[Layer] | None = None`, default = all layers
+  (unfiltered).** Principle: P4 (mechanism over menu) plus a safety rule — never
+  silently drop. `layer` is just another orthogonal filter like `kinds`; defaulting to
+  one layer would make `collect(kinds={section})` silently return `[]` (a
+  correctness-class surprise), whereas default-all returns visible, filterable
+  duplicates (a noise-class surprise).
+  Including-too-much is debuggable; silently-excluding is a footgun.
+  The cross-layer overlap is the layered model being honest (P3), not a bug; the fix is
+  the `layer=` filter plus documentation, not a privileged default.
+  Additive (P18).
+- **Canonical substrate — the source text + offset space, not the node table.**
+  Principle: P1 over the earlier DR-1 aspiration.
+  Amend the spec to name the offset space as canonical and the node table as *one*
+  projection (the id-addressed, layer-tagged, serialization-friendly one).
+  Do **not** refactor `blocks()`/`sections()`/`links()` to literally project from the
+  node-table id space — the node table is itself built from those parses, so inverting
+  the dependency is over-coupling.
+  Instead the simple model is “one memoized structural parse, many derived views sharing
+  the offset space”; the single-canonical-form ideal (P12/P15) holds at the level of the
+  parse + offset space.
+  Concretely this is the §3 wording correction (Phase 1) plus making `node_table()`
+  derive from the same memoized parse as `blocks()` (Phase 2), not a separate refactor.
+
+## References
+
+- Design of record: `docs/textdoc-spec.md`
+- Unified document model plan: `plan-2026-05-29-unified-document-model.md`
+- Research: `research-2026-05-29-document-model.md`,
+  `research-2026-05-30-multilayer-parsing.md`, `research-2026-05-30-span-references.md`
+- Document-structure epic: `chopdiff-d6js`
+
+<!-- This document follows common-doc-guidelines.md.
+See github.com/jlevy/practical-prose and review guidelines before editing.
+-->

--- a/docs/project/specs/active/plan-2026-05-31-golden-doc-testing.md
+++ b/docs/project/specs/active/plan-2026-05-31-golden-doc-testing.md
@@ -78,7 +78,8 @@ guarantees (cover, exact spans, round-trip, cross-serialization consistency).
      sections / TOC with rolled-up sizes, the full node table (id, layer, kind, span,
      parent, key attrs), links grouped by section, and SpanRef round-trips for located
      inline nodes.
-   - `doc_graph_yaml(graph: DocGraph) -> str` — the DocGraph as clean YAML.
+   - `doc_graph_yaml(doc: TextDoc) -> str` — the document’s default DocGraph as clean
+     YAML (a convenience over `doc.graph().to_yaml()`).
    - `dump_views(doc: TextDoc, dest: Path) -> None` — write the standard artifact set
      (`report.yaml`, `docgraph.yaml`, `reassembled.md`) for a document.
      The dumper builds plain dicts and serializes with

--- a/docs/project/specs/active/plan-2026-05-31-golden-doc-testing.md
+++ b/docs/project/specs/active/plan-2026-05-31-golden-doc-testing.md
@@ -1,0 +1,187 @@
+# Feature: Golden-Document Testing and a Reusable Doc-Model Debug Dumper
+
+**Date:** 2026-05-31 (last updated 2026-05-31)
+
+**Author:** Joshua Levy
+
+**Status:** Implemented
+
+## Overview
+
+chopdiff’s document model is fully deterministic and hermetic (no clock, network, LLM,
+or randomness; node ids are a deterministic preorder counter, sha256 and token estimates
+are deterministic). That makes it the ideal case for golden testing: no mock modes, no
+unstable-field scrubbing.
+This plan adds an end-to-end “golden document” test layer — a checked-in corpus of
+source documents, each converted by the model and serialized several ways, with the
+serializations committed as golden artifacts and compared on every run.
+
+The serializer is built as a **reusable developer tool**, not test-only glue: a public
+`chopdiff.docs.debug` dumper that can take any document and emit its model views in
+clean standard formats.
+Source documents are **Markdown with YAML frontmatter** (the frontmatter carries the
+test’s options); golden outputs are **pure, deterministic YAML**. We reuse
+`frontmatter-format` (first-party `jlevy` package, like `strif`/`flowmark`) for both the
+frontmatter I/O and the clean YAML formatting rather than reinventing either.
+
+The approach follows the golden-testing guideline’s transparent-box principle (capture
+broad state, not narrow asserts) plus layered invariant assertions for the model’s hard
+guarantees (cover, exact spans, round-trip, cross-serialization consistency).
+
+## Goals
+
+- **A reusable debug dumper (public).** `chopdiff.docs.debug` turns any `TextDoc` /
+  `DocGraph` into clean, standard-format views (a multi-view report, the DocGraph, the
+  reassembled source) usable from a REPL, a script, or the test harness.
+- **Clean YAML for DocGraph.** A deterministic, readable YAML serialization of
+  `DocGraph` alongside the existing JSON, via `frontmatter-format`’s `to_yaml_string`
+  (block style, key-sorted, `|` block scalars for multi-line text).
+- **A checked-in golden corpus.** A small set of representative Markdown+frontmatter
+  source documents and their golden YAML serializations, reviewed and committed with
+  code.
+- **Transparent-box coverage + layered invariants.** One readable artifact per document
+  shows every projection at once; targeted assertions enforce the model’s invariants
+  regardless of golden match.
+- **Reuse, don’t reinvent.** Adopt `frontmatter-format` for frontmatter parsing and
+  clean YAML.
+
+## Non-Goals
+
+- No CLI / tryscript console-golden tests (chopdiff is a library, not a CLI).
+- No mock-mode or unstable-field scrubbing machinery (not needed; the model is
+  hermetic).
+- Not a replacement for the focused unit tests — the golden corpus is the end-to-end
+  net; targeted invariant tests stay as the assertion layer.
+- No change to the `DocGraph/v0.1` schema; YAML is a second serialization of the same
+  model, not a new contract.
+
+## Background
+
+- A prototype dumper (run during review) confirmed the model serializes
+  deterministically and that one artifact can show source stats, the base-block
+  partition with a live cover check, TOC, the full node table (all layers), links by
+  section, SpanRef round-trips, and the DocGraph — all readable in well under the
+  golden-size budget.
+- `frontmatter-format` exposes `fmf_read` / `fmf_write(style=FmStyle.yaml)` / `Metadata`
+  for Markdown-with-frontmatter, and `to_yaml_string(value, key_sort=…)` / `dump_yaml`
+  (ruamel-backed) that already emit block-style, None-suppressed, key-sortable YAML with
+  `|` block scalars for multi-line strings — exactly the clean deterministic YAML we
+  want. It is MIT, first-party, `requires-python >=3.10`, and brings `ruamel.yaml`.
+
+## Design
+
+### Components
+
+1. **`chopdiff.docs.debug` (public dumper).** Pure functions over public API:
+   - `doc_report(doc: TextDoc) -> str` — the multi-view report as clean YAML: source
+     metadata (sha, length, size summary), base-block partition with `cover_ok`,
+     sections / TOC with rolled-up sizes, the full node table (id, layer, kind, span,
+     parent, key attrs), links grouped by section, and SpanRef round-trips for located
+     inline nodes.
+   - `doc_graph_yaml(graph: DocGraph) -> str` — the DocGraph as clean YAML.
+   - `dump_views(doc: TextDoc, dest: Path) -> None` — write the standard artifact set
+     (`report.yaml`, `docgraph.yaml`, `reassembled.md`) for a document.
+     The dumper builds plain dicts and serializes with
+     `frontmatter_format.to_yaml_string` under a fixed key order, so output is
+     deterministic and diff-friendly.
+2. **DocGraph → YAML.** A `DocGraph.to_yaml()` (or `doc_graph_yaml`) that dumps the
+   pydantic model via `to_yaml_string` with a stable key sort.
+   JSON (`model_dump_json`) stays the canonical wire form; YAML is the human/golden
+   form.
+3. **Corpus.** `tests/golden/documents/*.md`, each Markdown with a YAML frontmatter
+   block carrying the test’s name, a description, and options (e.g.
+   `item_partition_depth`, which `include` layers / `detail` flags to dump).
+   ~6 documents covering: kitchen-sink (headings, nested + ordered lists,
+   blockquote-with-table, inline + image links, code span); deep-nested list (base-block
+   depth + cover); tight-vs-loose list pair (density invariance); footnotes + reference
+   links (`span=None` handling); inline HTML / `<div>` (synthetic-layer precursor);
+   malformed Markdown (P17 tolerance); a unicode/emoji doc (code-point offsets).
+4. **Golden artifacts.**
+   `tests/golden/expected/<doc>/{report.yaml,docgraph.yaml, reassembled.md}` — sharded
+   per document (guideline: many small artifacts), pure YAML + the reassembled Markdown.
+5. **Harness.** `tests/golden/test_golden_docs.py`: discover each source doc, read its
+   frontmatter for options via `fmf_read`, build the `TextDoc`, render the artifacts,
+   compare to the goldens, and fail on diff.
+   `UPDATE_GOLDEN=1` rewrites the goldens.
+6. **Layered invariant assertions** (run every time, independent of golden match):
+   base-block cover over all non-whitespace source (P13); `source_text[s:e] == quote`
+   for every source-backed node/sentence (P6); node ids unique and every
+   `parent`/`children` ref resolves; DocGraph child refs valid; `reassemble()`
+   round-trips at the Markdown-object level (P11); and a cross-serialization check that
+   the DocGraph node spans equal the report’s node spans (the copies agree).
+7. **Docs.** `tests/golden/README.md` documenting the corpus, the artifact set, and the
+   update/review workflow.
+
+### Dependency
+
+`frontmatter-format` is adopted for frontmatter I/O and clean YAML (brings
+`ruamel.yaml`). Adoption follows `SUPPLY-CHAIN-SECURITY.md` (add an `exclude-newer`
+cool-off entry, commit the lockfile, install frozen).
+It is first-party (`jlevy`), matching the existing `strif` / `flowmark` review pattern.
+See Open Decisions for runtime-vs-extra placement.
+
+### API Changes
+
+- **Additive (public):** new module `chopdiff.docs.debug` (`doc_report`,
+  `doc_graph_yaml`, `dump_views`) and a `DocGraph.to_yaml()` method.
+  No existing surface changes.
+
+## Implementation Plan
+
+### Phase 1: Reusable dumper + DocGraph YAML
+
+- [x] Adopt `frontmatter-format` per `SUPPLY-CHAIN-SECURITY.md` (cool-off entry,
+  lockfile).
+- [x] Add `DocGraph.to_yaml()` (clean, key-sorted YAML via `to_yaml_string`); keep JSON.
+- [x] Build `chopdiff.docs.debug` with `doc_report`, `doc_graph_yaml`, `dump_views`,
+  emitting deterministic clean YAML; export it.
+- [x] A few inline/unit checks that the dumper is deterministic (same input → identical
+  bytes) and that YAML re-parses to the expected structure.
+
+### Phase 2: Golden corpus and harness
+
+- [x] Create `tests/golden/documents/*.md` (Markdown + frontmatter) covering the cases
+  above.
+- [x] Implement `tests/golden/test_golden_docs.py`: per-doc render + compare,
+  `UPDATE_GOLDEN` rewrite, and the layered invariant assertions.
+- [x] Generate and review the initial golden artifacts; commit them.
+- [x] Add `tests/golden/README.md` (corpus + update/review workflow).
+- [x] Confirm `make lint` and `make test` clean and that an intentional model change
+  shows up as a reviewable golden diff.
+
+## Testing Strategy
+
+- The corpus + golden compare is the end-to-end transparent-box layer; the invariant
+  assertions are the targeted layer (guideline principle 7), so a semantic violation
+  fails even if goldens are blindly regenerated.
+- Determinism is verified by re-rendering and byte-comparing; no scrubbing needed.
+- Keep total golden YAML well under the size budget (small docs, sharded artifacts).
+
+## Rollout Plan
+
+- Additive: a new public module, a new method, a new test tree, one new (first-party)
+  dependency. Land Phase 1 then Phase 2; each is independently shippable.
+
+## Open Decisions
+
+- **`frontmatter-format` placement — runtime dependency vs optional `[debug]` extra.**
+  Recommended: **runtime dependency**, since the dumper is meant to be reused and
+  `frontmatter-format` is small and first-party.
+  Alternative: keep core lean by gating the YAML/dumper behind a `chopdiff[debug]` extra
+  (+ dev dependency for the harness) with a clear ImportError when absent.
+  Decide before Phase 1.
+- **Artifact granularity** — sharded `report.yaml` / `docgraph.yaml` / `reassembled.md`
+  (recommended, per guideline) vs one combined report.
+  Sharded keeps each diff focused.
+
+## References
+
+- Golden-testing guideline: `tbd guidelines golden-testing-guidelines`
+- Doc-model design of record: `docs/textdoc-spec.md`
+- Doc-model refinements plan: `plan-2026-05-31-doc-model-refinements.md`
+- `frontmatter-format`: https://github.com/jlevy/frontmatter-format (source in `attic/`)
+- Supply-chain policy: `SUPPLY-CHAIN-SECURITY.md`
+
+<!-- This document follows common-doc-guidelines.md.
+See github.com/jlevy/practical-prose and review guidelines before editing.
+-->

--- a/docs/textdoc-spec.md
+++ b/docs/textdoc-spec.md
@@ -336,8 +336,11 @@ Document manipulation and processing happen base block by base block.
 HTML, and a whole **blockquote**) are each one base block.
 **Lists decompose:** each **list item, at every nesting level, is its own base block**
 with increasing `depth` (flat-with-depth).
-An item holding a nested list contributes its own content at depth *d* and its nested
-items follow at *d+1*, which keeps the partition non-overlapping.
+An item holding a nested list contributes a `list_item` **head** block (the marker and
+lead content) at depth *d*, then its nested items at *d+1*; any **continuation** content
+(paragraphs after or between sublists) follows as base blocks carrying their **own real
+block type** (e.g. `paragraph`) at depth *d* — never relabeled `list_item`, so a
+consumer can tell a continuation paragraph apart from an independent list item.
 
 How deep lists decompose is one numeric parameter,
 `base_blocks(item_partition_depth=6)`:
@@ -352,13 +355,17 @@ How deep lists decompose is one numeric parameter,
 Blockquotes are always one base block regardless of `item_partition_depth`.
 
 **Invariants** (validated and documented): the base-block list is **ordered** by
-position, **non-overlapping** by span, and a **complete cover**. Reassembling the base
-blocks in order reproduces the document **exactly except for normalized paragraph-break
-whitespace** (runs of blank lines between blocks); every base block also retains its
-exact `source_span`, so a byte-for-byte reconstruction is available from offsets when
-needed. A pipeline may process, edit, or **resequence** base blocks and reassemble;
-`depth` is mutable metadata, so promoting a depth-2 item to depth-1 on a move just
-changes its rendered nesting, not a violation.
+position, **non-overlapping** by span, and together the spans **cover every
+non-whitespace character exactly once** (the gaps are inter-block and structural
+whitespace). Every base block retains its exact `source_span`, so **exact source
+reconstruction is by slicing the source at those spans** (or via the structural
+`blocks()` tree). Reassembling the rendered base-block *text* is **lossy for list-item
+continuation content** — list markers and continuation indentation are whitespace
+outside the trimmed spans, so naive text concatenation normalizes them; reconstruct from
+offsets when exactness matters.
+A pipeline may process, edit, or **resequence** base blocks; `depth` is mutable
+metadata, so promoting a depth-2 item to depth-1 on a move just changes its rendered
+nesting, not a violation.
 
 ## 7. Sections and TOC
 

--- a/docs/textdoc-spec.md
+++ b/docs/textdoc-spec.md
@@ -1,17 +1,18 @@
 # TextDoc and DocGraph: Design Specification
 
-**Status:** Definitive front-to-back design of chopdiff's document model: the `TextDoc`
-Python core and the `DocGraph` serialized projection. The design is settled (decision
-records DR-1..DR-6 in
+**Status:** Definitive front-to-back design of chopdiff’s document model: the `TextDoc`
+Python core and the `DocGraph` serialized projection.
+The design is settled (decision records DR-1..DR-6 in
 [`plan-2026-05-29-unified-document-model.md`](project/specs/active/plan-2026-05-29-unified-document-model.md));
-see §14 for what is implemented (v0.4.0) versus in progress. Dated plans under
-`docs/project/specs/` describe the incremental work toward this design.
+see §14 for what is implemented (v0.4.0) versus in progress.
+Dated plans under `docs/project/specs/` describe the incremental work toward this
+design.
 
 ## 1. Purpose
 
 The document model consolidates, in one source-anchored structure, what a document
-analysis or editing task normally needs from separate tools, and anchors every piece back
-to the source by exact character offset:
+analysis or editing task normally needs from separate tools, and anchors every piece
+back to the source by exact character offset:
 
 - **Markdown block structure:** headings, paragraphs, lists/list items, tables, code,
   blockquotes, HTML, footnotes, thematic breaks.
@@ -29,62 +30,144 @@ Two surfaces, one design:
 - **`TextDoc`** is the **Python core:** the in-process object for parsing, analysis,
   rollups, transforms, and editable reassembly.
 - **`DocGraph`** is the **serialized, language-neutral projection** of the same content:
-  a JSON contract for frontends, cross-language clients, and annotations. It is derived
-  from `TextDoc`, not a competing model (DR-2).
+  a JSON contract for frontends, cross-language clients, and annotations.
+  It is derived from `TextDoc`, not a competing model (DR-2).
 
-## 2. Goals
+## 2. Principles and Goals
 
-- **One consolidating structure.** Markdown block, inline, language, and document structure
-  in one object, not four tools stitched together.
-- **Exact source anchoring.** Every unit references the source by `[start, end)`; spans
-  round-trip verbatim; no copies, no drift. Offsets are **Unicode code points**.
-- **Normalized form, derived views.** One canonical form: a stable node table; section
-  hierarchy, block-type slices, element rollups, and tallies are *calculated fields* over
-  it, never stored. If a view is hard to derive, refine the form.
-- **Simplicity with flexibility (mechanism over menu).** One general query primitive
-  (`collect()`), composable serialization layers (`include`), not a fixed menu of blessed
-  rollups or detail levels, so the model serves many downstream uses without per-need API
-  changes (DR-4, DR-5).
-- **Markdown-correspondent block types.** One-to-one with Markdown kinds (bullet vs.
-  ordered lists distinct); each block has one top-level type; nesting is recursive and
-  fully populated.
-- **Two block views.** A recursive **structural block tree** (for nesting/slicing/queries)
-  and a flat **sequential base-block list** (a complete, ordered, non-overlapping partition
-  whose reassembly reproduces the document), so a pipeline can process or resequence a
-  document block by block.
-- **Density-invariant lists.** Tight and loose lists produce identical tallies.
-- **Source-canonical references.** A span reference is durable for annotations across edits
-  (`SpanRef`, DR-6): a text quote is the canonical anchor, offsets are recomputable hints.
-- **Cross-language contract.** `DocGraph` is a boring, parser-agnostic JSON schema
-  (Pydantic-authored, DR-3); Python and any future TypeScript/Rust client are
+The design rests on a small spine of foundational principles; the capability and
+pragmatic principles below are consequences of it, and the goals that follow each
+realize one or more of them.
+Every later decision should cite the principle it serves.
+
+### Principles
+
+**Tier 1 — Foundational (the spine):**
+
+- **P1. One immutable source, one shared offset space, is the canonical substrate.**
+  Every structure aligns to `source_text` by exact `[start, end)` in Unicode code
+  points. This, not any one parsed structure, is what unifies the model.
+- **P2. Source is canonical; every structural model is a derived, re-derivable
+  projection.** Edits go through the source/editing view and re-derive; the parsed model
+  is read-mostly and never drifts from the text (DR-1/DR-2).
+- **P3. Layered parsing; cross-layer relationships are offset-containment queries, not
+  stored edges.** The same source is parsed along independent dimensions (textual,
+  markdown, document, synthetic), each tagged by `layer`; relations *between* layers are
+  interval containment, never persisted edges.
+- **P4. Mechanism over menu.** One general query primitive (`collect()`) and two
+  composable serialization axes (`include` layers / `detail` payloads); no blessed
+  per-kind rollups or fixed detail ladders.
+  New capability is one additive layer or detail, not an API refactor (DR-4/DR-5).
+- **P5. Model ≠ format ≠ implementation.** The contract is a language-neutral JSON
+  schema (Pydantic-authored, DR-3); Python today, Rust/TypeScript later, implement one
+  frozen contract.
+
+**Tier 2 — Representation (what the model must faithfully carry):**
+
+- **P6. Exact ground-truth references** (`source_text[s:e] == original_text`).
+- **P7. Faithful, complete Markdown structure** — all modern block and inline kinds
+  (tables, footnotes, fenced code, blockquotes, inline/block HTML, images); one
+  top-level type per block; recursive, fully-populated nesting; bullet vs.
+  ordered distinct.
+- **P8. Textual structure with clean round-trip** — paragraphs/sentences/wordtoks as the
+  editing view; edit units and `reassemble()`.
+- **P9. Document structure** — heading hierarchy, sections, and TOC, with section
+  containment ("which paragraphs are in which section").
+- **P10. Synthetic tag structure** — a small marker-tag whitelist (today
+  `<div>`/`<span>`) as a first-class layer, not a special case.
+- **P11. Clean whole-tree round-trip editing** — after arbitrary edits, reproduce a
+  document with Markdown-object-level equivalence, and byte-exact equivalence when
+  Flowmark-normalized or reconstructed from retained offsets (two distinct equivalence
+  levels).
+
+**Tier 3 — Pragmatics (cost, ergonomics, robustness):**
+
+- **P12. Single canonical form, derived views, no stored counts** — sections, slices,
+  and tallies are calculated fields; if a view is hard to derive, refine the form.
+- **P13. Complete base-block partition** — a flat, ordered, non-overlapping,
+  depth-annotated cover of the whole document that reassembles to the source.
+- **P14. Serializable projections** — full parse or any slice to language-neutral JSON
+  for frontends.
+- **P15. Parse cost ≈ one Markdown parse; expensive views are lazy** — pay for costly
+  rollups on demand, cached on the immutable source.
+- **P16. Approximation where cheap and sufficient** — fast regex sentence segmentation
+  and heuristic token sizing are accepted; exactness is reserved for offsets/spans.
+- **P17. Graceful tolerance of malformed input** — never throw on bad Markdown; degrade
+  to best-effort structure.
+- **P18. Additive evolution** — existing diff/window/wordtok behavior preserved; new
+  layers and details are additive.
+
+### Goals
+
+Each goal realizes the principle(s) noted.
+
+- **One consolidating structure** (P7, P8, P9). Markdown block, inline, language, and
+  document structure in one object, not four tools stitched together.
+- **Exact source anchoring** (P1, P6). Every unit references the source by
+  `[start, end)`; spans round-trip verbatim; no copies, no drift.
+  Offsets are **Unicode code points**.
+- **Normalized form, derived views** (P12). One canonical form anchored to the offset
+  space; section hierarchy, block-type slices, element rollups, and tallies are
+  *calculated fields*, never stored.
+  If a view is hard to derive, refine the form.
+- **Simplicity with flexibility (mechanism over menu)** (P4). One general query
+  primitive (`collect()`), composable serialization layers (`include`), not a fixed menu
+  of blessed rollups or detail levels, so the model serves many downstream uses without
+  per-need API changes (DR-4, DR-5).
+- **Markdown-correspondent block types** (P7). One-to-one with Markdown kinds (bullet
+  vs. ordered lists distinct); each block has one top-level type; nesting is recursive
+  and fully populated.
+- **Two block views** (P13). A recursive **structural block tree** (for
+  nesting/slicing/queries) and a flat **sequential base-block list** (a complete,
+  ordered, non-overlapping partition whose reassembly reproduces the document), so a
+  pipeline can process or resequence a document block by block.
+- **Density-invariant lists** (P7, P12). Tight and loose lists produce identical
+  tallies.
+- **Source-canonical references** (P1, P2). A span reference is durable for annotations
+  across edits (`SpanRef`, DR-6): a text quote is the canonical anchor, offsets are
+  recomputable hints.
+- **Cross-language contract** (P5, P14). `DocGraph` is a boring, parser-agnostic JSON
+  schema (Pydantic-authored, DR-3); Python and any future TypeScript/Rust client are
   implementations of one contract.
-- **Dual use.** Analysis of a fixed document *and* an editable model: modify units,
-  reassemble, serialize a clean normalized document.
-- **LLM/agent-friendly, Python-first, Rust-portable.** Ergonomic from Python and from
-  LLM/agent code; a tight spec and thorough tests make a Rust port feasible.
-- **Minimal dependencies; additive.** Existing diff/window/wordtok behavior preserved.
+- **Dual use** (P8, P11). Analysis of a fixed document *and* an editable model: modify
+  units, reassemble, serialize a clean normalized document.
+- **LLM/agent-friendly, Python-first, Rust-portable** (P5). Ergonomic from Python and
+  from LLM/agent code; a tight spec and thorough tests make a Rust port feasible.
+- **Minimal dependencies; additive** (P18). Existing diff/window/wordtok behavior
+  preserved.
 
 ## 3. The Normalized Form
 
 Everything is aligned by span into a single retained `source_text`. The **canonical
-structure is a node table**, a stable set of nodes addressable by id and span, from which
-every other structure is a derived view (DR-1):
+substrate is the source text plus its offset space** (P1): every structure references
+the source by exact `[start, end)` (Unicode code points) and is a derived projection.
+The **node table** is the primary such projection — a stable set of nodes addressable by
+id and span — and is what the serialized contract and cross-layer queries are built on
+(DR-1):
 
 1. **Source:** `source_text` plus exact `[start, end)` spans (Unicode code points); each
-   unit's `original_text` is a computed slice, exact by construction.
-2. **Node table:** one node per block, inline element, and heading: `Node{id, kind,
-   parent, children, source_span, attrs}`. Block containment is `parent`/`children`; this
-   is taken from marko's parse and *referenced*, not duplicated.
+   unit’s `original_text` is a computed slice, exact by construction.
+2. **Node table:** one node per block, inline element, and heading:
+   `Node{id, kind, parent, children, source_span, attrs}`. Block containment is
+   `parent`/`children`; this is taken from marko’s parse and *referenced*, not
+   duplicated.
 3. **Language structure:** paragraphs, sentences, and the wordtok view, with spans and
    spacing tokens (the editing view).
 
-Why a node table and not a single tree: a document has several hierarchies that overlap and
-do not nest: a **section** spans sibling blocks and is not a subtree of the block tree;
-**links** are inline ranges; **annotations** target arbitrary spans. A single canonical tree
-privileges one hierarchy and forces the rest into bespoke overlays. A node table gives one
-id space for blocks *and* inline items, so the containment tree, section tree, block list,
-link index, and token stream are all O(n) projections that share ids, and the serialized
-JSON still presents a `document` root with children as its top-level shape.
+Why a node table and not a single tree: a document has several hierarchies that overlap
+and do not nest: a **section** spans sibling blocks and is not a subtree of the block
+tree; **links** are inline ranges; **annotations** target arbitrary spans.
+A single canonical tree privileges one hierarchy and forces the rest into bespoke
+overlays. A node table gives one id space for blocks *and* inline items, so the
+containment tree, section tree, block list, link index, and token stream all share one
+id space, and the serialized JSON still presents a `document` root with children as its
+top-level shape.
+
+The ergonomic Python views (`blocks()`, `sections()`, `links()`, `base_blocks()`) and
+the node table both derive from the same memoized structural parse over the shared
+offset space; they are sibling projections, not a store and lookups into it.
+This keeps parse cost at roughly one Markdown parse (P15) without coupling every view to
+the node-table schema.
 
 **Views over the form.** Several ways to walk the same `source_text`, none of them the
 canonical store:
@@ -96,12 +179,13 @@ canonical store:
 - the **section tree** (heading hierarchy);
 - the **inline/link index**.
 
-The editing view's block boundaries are unchanged by the structural tree, so there is no
+The editing view’s block boundaries are unchanged by the structural tree, so there is no
 forced migration of the editing unit.
 
-**Parse layers.** Those views are not ad-hoc; each is one **parse layer** over the shared
-offset space. chopdiff parses the same `source_text` along several independent dimensions,
-each contributing nodes tagged with their `layer`:
+**Parse layers.** Those views are not ad-hoc; each is one **parse layer** over the
+shared offset space.
+chopdiff parses the same `source_text` along several independent dimensions, each
+contributing nodes tagged with their `layer`:
 
 | Layer | Produces | Depends on | Nesting guarantee |
 | --- | --- | --- | --- |
@@ -112,31 +196,34 @@ each contributing nodes tagged with their `layer`:
 
 Two consequences define how layers interact:
 
-- **Cross-layer relationships are offset-containment queries, not stored edges.** Within a
-  layer, navigate `parent`/`children`; *across* layers, use interval containment/overlap
-  ("which markdown blocks are inside this `<div>`", "which section contains this link").
-  This is what lets layers overlap and cross-cut without contradiction (a section is not a
-  subtree of the block tree; a `<div>` may open mid-block).
-- **Each layer declares a nesting guarantee:** well-nested layers project to a tree view,
-  ordered-only layers to a sequential list view (the §6 tree-vs-partition distinction,
-  generalized). The `SpanRef`-targeted annotation layer (§11) is the out-of-band layer,
-  anchored to the same offset space.
+- **Cross-layer relationships are offset-containment queries, not stored edges.** Within
+  a layer, navigate `parent`/`children`; *across* layers, use interval
+  containment/overlap ("which markdown blocks are inside this `<div>`", “which section
+  contains this link”). This is what lets layers overlap and cross-cut without
+  contradiction (a section is not a subtree of the block tree; a `<div>` may open
+  mid-block).
+- **Each layer declares a nesting guarantee:** well-nested layers project to a tree
+  view, ordered-only layers to a sequential list view (the §6 tree-vs-partition
+  distinction, generalized).
+  The `SpanRef`-targeted annotation layer (§11) is the out-of-band layer, anchored to
+  the same offset space.
 
 The **synthetic layer is a general mechanism, not a `<div>` special case:** synthetic
-structure is introduced by a small, defined vocabulary of marker tags that delimit regions
-for chunking, grouping, and in-band metadata. The vocabulary is a fixed, known whitelist and
-can take any of these forms:
+structure is introduced by a small, defined vocabulary of marker tags that delimit
+regions for chunking, grouping, and in-band metadata.
+The vocabulary is a fixed, known whitelist and can take any of these forms:
 
 - standard HTML containers, today `<div>`/`<span>` via `TextNode`;
 - custom semantic XML tags such as `<chunk>`;
-- comment-delimited (Markdoc-style) directives such as `<!-- chunk id="foo" -->`, which carry
-  structure in Markdown without rendering.
+- comment-delimited (Markdoc-style) directives such as `<!-- chunk id="foo" -->`, which
+  carry structure in Markdown without rendering.
 
-The layer carries each region as a node with its tag name and attributes in `attrs`, so a new
-marker tag is configuration (an entry in the whitelist), not a new code path.
+The layer carries each region as a node with its tag name and attributes in `attrs`, so
+a new marker tag is configuration (an entry in the whitelist), not a new code path.
 
-Layers are **enabled à la carte** (a configuration, not a fork): today's `TextNode` tag
-subsystem is "the synthetic layer alone," and the full analysis path enables several. See
+Layers are **enabled à la carte** (a configuration, not a fork): today’s `TextNode` tag
+subsystem is “the synthetic layer alone,” and the full analysis path enables several.
+See
 [`research-2026-05-30-multilayer-parsing.md`](project/research/research-2026-05-30-multilayer-parsing.md)
 for the framing and prior art.
 
@@ -144,165 +231,177 @@ for the framing and prior art.
 
 - `TextDoc`: retains `source_text`; owns the `Paragraph` list (editing view) and the
   derived, lazily-cached node table and views.
-- `Node`: `id` (stable within a parse), `kind` (a `BlockType` or an inline kind), `layer`
-  (the parse dimension it belongs to, textual / markdown / document / synthetic; §3),
-  `parent`, `children`, `source_span`, `attrs` (e.g. heading level, `List.ordered`/`tight`,
-  link url/title). `parent`/`children` are within-layer edges; cross-layer relationships are
-  offset-containment queries (§3). Parser-internal details live in `attrs`/`metadata`, never
-  in stable public fields.
+- `Node`: `id` (stable within a parse), `kind` (a `BlockType` or an inline kind),
+  `layer` (the parse dimension it belongs to, textual / markdown / document / synthetic;
+  §3), `parent`, `children`, `source_span`, `attrs` (e.g. heading level,
+  `List.ordered`/`tight`, link url/title).
+  `parent`/`children` are within-layer edges; cross-layer relationships are
+  offset-containment queries (§3). Parser-internal details live in `attrs`/`metadata`,
+  never in stable public fields.
 - `Paragraph`: a blank-line block: `sentences`, `Offsets`, `span`, cached top-level
   `block_type`, computed `original_text`, helpers (`heading_level()`, `heading_title()`,
   `links()`).
-- `Sentence`: `text` (normalized, editable; what wordtoks/diffs/reassemble use), `Offsets`,
-  `span`, verbatim `original_text` computed from the span.
+- `Sentence`: `text` (normalized, editable; what wordtoks/diffs/reassemble use),
+  `Offsets`, `span`, verbatim `original_text` computed from the span.
 - `Offsets(doc_offset, block_offset)`: `doc_offset` absolute; `block_offset` relative to
   the parent. **Offset unit is Unicode code points** (Python-native); `DocGraph` may
-  expose derived `byte_span`/`utf16_span` for byte- or browser-oriented consumers, but the
-  canonical `source_span` is code points (the cross-language footgun the W3C position
-  selector left unresolved).
+  expose derived `byte_span`/`utf16_span` for byte- or browser-oriented consumers, but
+  the canonical `source_span` is code points (the cross-language footgun the W3C
+  position selector left unresolved).
 - `TextDoc.block_at_offset(o)` / `sentence_at_offset(o)` invert spans.
 
 Invariant: `source_text[unit.span[0]:unit.span[1]] == unit.original_text` for every
 source-backed unit. Synthetic docs (`from_wordtoks`, `append_sent`) have no source, so
 `source_text` is the reassembled working text.
 
-Sentence spans are exact for all content via flowmark's `split_sentences_with_spans`:
+Sentence spans are exact for all content via flowmark’s `split_sentences_with_spans`:
 `SentenceSpan`s are verbatim and never bisect a link, code span, autolink, or URL.
 `Sentence.text` stays whitespace-normalized; `original_text`/spans are verbatim.
 
 ## 5. Block-Type Model
 
-`BlockType` corresponds one-to-one to Markdown block kinds: `heading`, `paragraph`, `list`
-(bullet/unordered), `ordered_list`, `list_item`, `table`, `code`, `blockquote`, `html`,
-`footnote`, `thematic_break`.
+`BlockType` corresponds one-to-one to Markdown block kinds: `heading`, `paragraph`,
+`list` (bullet/unordered), `ordered_list`, `list_item`, `table`, `code`, `blockquote`,
+`html`, `footnote`, `thematic_break`.
 
-- **Bullet vs. ordered lists are distinct types.** marko's `List` carries `ordered`; `list`
-  is the bullet list, `ordered_list` is enumerated, `list_item` is shared.
+- **Bullet vs. ordered lists are distinct types.** marko’s `List` carries `ordered`;
+  `list` is the bullet list, `ordered_list` is enumerated, `list_item` is shared.
 - **One top-level type per block,** from its **outer** element: a blockquote wrapping a
-  table classifies as `blockquote` at the top level. This is what the top-level views and
-  default rollups key on.
-- **Nesting is recursive and fully populated.** Every container (blockquote, list item) has
-  its block children in the node table, so a table nested inside a blockquote *is* a node
-  and is found by a recursive `collect()`. The inner table keeps its own `table` kind;
-  default (shallow) rollups attribute it to its enclosing top-level block, recursive rollups
-  count it directly.
+  table classifies as `blockquote` at the top level.
+  This is what the top-level views and default rollups key on.
+- **Nesting is recursive and fully populated.** Every container (blockquote, list item)
+  has its block children in the node table, so a table nested inside a blockquote *is* a
+  node and is found by a recursive `collect()`. The inner table keeps its own `table`
+  kind; default (shallow) rollups attribute it to its enclosing top-level block,
+  recursive rollups count it directly.
 
-**List density must not change tallies.** A dense list and the same list written sparsely
-are the same list. In the structural tree a list **always decomposes into `list_item`
-children regardless of density**: a loose list is *one* list block with
-blank-line-separated items, not N lists, so `len(list.children)` and any tally are
-density-invariant. Density is metadata, not structure: a `tight: bool` on the list
-(CommonMark semantics); the flag never enters a tally.
+**List density must not change tallies.** A dense list and the same list written
+sparsely are the same list.
+In the structural tree a list **always decomposes into `list_item` children regardless
+of density**: a loose list is *one* list block with blank-line-separated items, not N
+lists, so `len(list.children)` and any tally are density-invariant.
+Density is metadata, not structure: a `tight: bool` on the list (CommonMark semantics);
+the flag never enters a tally.
 
 ## 6. Block Views: Structural Tree and Sequential Base-Block List
 
-**Terminology.** To avoid overloading "block":
+**Terminology.** To avoid overloading “block”:
 
 - **block element** / **inline element:** the Markdown element *class* (CommonMark/mdast
-  sense): block-level (heading, paragraph, blockquote, list, list item, table, code, …) vs
-  inline (link, code span, emphasis, …).
+  sense): block-level (heading, paragraph, blockquote, list, list item, table, code, …)
+  vs inline (link, code span, emphasis, …).
 - **block node:** a node with a block kind in the recursive **structural block tree**
   (`blocks()`); containers (blockquote, list, list item) contain child block nodes.
 - **base block:** a unit of the flat **sequential block list** (`base_blocks()`): a
   complete, ordered, non-overlapping partition of the document into the units a pipeline
   processes or a UI resequences.
 
-These are two views of the same node table, for two different jobs (and they must not be
-conflated; see §9: the tree supports *queries* that may overlap; the base-block list is a
-*partition* with a cover invariant).
+These are two views over the same shared parse, for two different jobs (and they must
+not be conflated; see §9: the tree supports *queries* that may overlap; the base-block
+list is a *partition* with a cover invariant).
 
 ### Structural block tree: `TextDoc.blocks() -> list[Block]`
 
-The recursive view (lazy, cached):
+The recursive view (lazy, cached on the immutable `source_text`):
 
 - `Block(type, span, children, tight)`: `span` is trimmed so `source[start:end]` is the
-  exact text; `children` holds nested blocks. A `list`/`ordered_list` block's children are
-  its `list_item`s; **containers fully populate their block children** (a blockquote's or
-  list item's nested blocks are present). `tight` carries CommonMark list density on list
-  blocks (`None` elsewhere).
+  exact text; `children` holds nested blocks.
+  A `list`/`ordered_list` block’s children are its `list_item`s; **containers fully
+  populate their block children** (a blockquote’s or list item’s nested blocks are
+  present). `tight` carries CommonMark list density on list blocks (`None` elsewhere).
 - Resolves what blank-line splitting cannot: a fenced code block stays whole even with
-  internal blank lines; a list decomposes into items with nested sublists; a table inside a
-  blockquote is reachable.
+  internal blank lines; a list decomposes into items with nested sublists; a table
+  inside a blockquote is reachable.
 
-Block boundaries and spans come straight from flowmark's parser: every block element
-carries an authoritative `element.span = (start, end)` read from marko's own source
-positions (`flowmark.markdown_ast.block_span`), so chopdiff runs no block-detection regex of
-its own and makes no block-boundary decisions. The structure is cross-checked against marko
-in tests.
+Block boundaries and spans come straight from flowmark’s parser: every block element
+carries an authoritative `element.span = (start, end)` read from marko’s own source
+positions (`flowmark.markdown_ast.block_span`), so chopdiff runs no block-detection
+regex of its own and makes no block-boundary decisions.
+The structure is cross-checked against marko in tests.
 
-### Sequential block list: `TextDoc.base_blocks() -> list[Block]`
+### Sequential block list: `TextDoc.base_blocks() -> list[BaseBlock]`
 
-A **base block is a block node** (the same `Block`/node type), but the **base-block list**
-is a *partition* of the document: the ordered sequence of base blocks, each carrying a
-`depth`. It is the view for block-by-block pipelines and outline UIs that move/resequence
-blocks (e.g. Notion-style drag-and-drop, where every item is a draggable unit). chopdiff
-does not implement such UIs, but the model supports addressing and reordering at this
-granularity. Document manipulation and processing happen base block by base block.
+A **base block** is a `BaseBlock` wrapping a block node (`Block`) with a `depth`; the
+**base-block list** is a *partition* of the document: the ordered sequence of base
+blocks, each carrying its `depth`. `TextDoc.base_blocks()` is a thin method over the
+`chopdiff.docs.base_blocks.base_blocks(text, *, item_partition_depth=6)` free function
+(the partition lives in its own module, distinct from the recursive tree in
+`block_tree.py`). It is the view for block-by-block pipelines and outline UIs that
+move/resequence blocks (e.g. Notion-style drag-and-drop, where every item is a draggable
+unit). chopdiff does not implement such UIs, but the model supports addressing and
+reordering at this granularity.
+Document manipulation and processing happen base block by base block.
 
 **Frontier.** Leaf and atomic blocks (heading, paragraph, table, code, thematic break,
-HTML, and a whole **blockquote**) are each one base block. **Lists decompose:** each **list
-item, at every nesting level, is its own base block** with increasing `depth`
-(flat-with-depth). An item holding a nested list contributes its own content at depth *d*
-and its nested items follow at *d+1*, which keeps the partition non-overlapping.
+HTML, and a whole **blockquote**) are each one base block.
+**Lists decompose:** each **list item, at every nesting level, is its own base block**
+with increasing `depth` (flat-with-depth).
+An item holding a nested list contributes its own content at depth *d* and its nested
+items follow at *d+1*, which keeps the partition non-overlapping.
 
-How deep lists decompose is one numeric parameter, `base_blocks(item_partition_depth=6)`:
+How deep lists decompose is one numeric parameter,
+`base_blocks(item_partition_depth=6)`:
 
-- `item_partition_depth = N` (default **6**, deep enough for normal nested lists): split list items
-  down to *N* nesting levels; list content nested deeper than *N* stays whole inside its
-  depth-*N* base block (avoids pathological fan-out on very deep lists).
+- `item_partition_depth = N` (default **6**, deep enough for normal nested lists): split
+  list items down to *N* nesting levels; list content nested deeper than *N* stays whole
+  inside its depth-*N* base block (avoids pathological fan-out on very deep lists).
 - `item_partition_depth = -1`: unlimited; split at every nesting level.
-- `item_partition_depth = 0`: lists are not split; each list is a single base block (coarse mode,
-  i.e. the top-level blocks).
+- `item_partition_depth = 0`: lists are not split; each list is a single base block
+  (coarse mode, i.e. the top-level blocks).
 
 Blockquotes are always one base block regardless of `item_partition_depth`.
 
-**Invariants** (validated and documented): the base-block list is **ordered** by position,
-**non-overlapping** by span, and a **complete cover**. Reassembling the base blocks in order
-reproduces the document **exactly except for normalized paragraph-break whitespace** (runs
-of blank lines between blocks); every base block also retains its exact `source_span`, so a
-byte-for-byte reconstruction is available from offsets when needed. A pipeline may process,
-edit, or **resequence** base blocks and reassemble; `depth` is mutable metadata, so promoting
-a depth-2 item to depth-1 on a move just changes its rendered nesting, not a violation.
+**Invariants** (validated and documented): the base-block list is **ordered** by
+position, **non-overlapping** by span, and a **complete cover**. Reassembling the base
+blocks in order reproduces the document **exactly except for normalized paragraph-break
+whitespace** (runs of blank lines between blocks); every base block also retains its
+exact `source_span`, so a byte-for-byte reconstruction is available from offsets when
+needed. A pipeline may process, edit, or **resequence** base blocks and reassemble;
+`depth` is mutable metadata, so promoting a depth-2 item to depth-1 on a move just
+changes its rendered nesting, not a violation.
 
 ## 7. Sections and TOC
 
 A derived hierarchy over heading nodes, no re-parse:
 
 - `Section`: heading, `level`, the content it owns (up to the next heading of level ≤
-  this), child `Section`s. Content/span/sizes are computed; `Section.blocks()` is the block
-  tree scoped to the section.
+  this), child `Section`s. Content/span/sizes are computed; `Section.blocks()` is the
+  block tree scoped to the section.
 - `TextDoc.sections()` → tree; `toc()` → flat `(level, title, span)`.
-- Sizes reuse `TextDoc.size`: `Section.size(unit, subtree=True|False)`, `size_summary()`,
-  `TextDoc.section_size_tree(units=…)`. Every `TextUnit` rolls up uniformly.
+- Sizes reuse `TextDoc.size`: `Section.size(unit, subtree=True|False)`,
+  `size_summary()`, `TextDoc.section_size_tree(units=…)`. Every `TextUnit` rolls up
+  uniformly.
 
 ## 8. Inline Elements and Links
 
-Inline elements (links, code spans, images, …) are **first-class nodes** whose `parent` is
-their containing block, with computed `section`/`sentence` associations, so block↔inline
-relationships are node edges, and "links in section 3" is a scoped `collect(kinds={link})`.
+Inline elements (links, code spans, images, …) are **first-class nodes** whose `parent`
+is their containing block, with computed `section`/`sentence` associations, so
+block↔inline relationships are node edges, and “links in section 3” is a scoped
+`collect(kinds={link})`.
 
 - `Link(text, url, title, span)`: identity from `flowmark.markdown_ast.extract_links`
-  (reference links resolved, escapes honored, autolinks/images handled), which carries no
-  span by design. chopdiff recovers each exact `[start, end)` by reconciling the ordered
-  identities with the name-tagged atomic spans from `flowmark.atomic_spans.iter_atomic_spans`
-  (`markdown_link` / `autolink` / `bare_url`); reference links keep identity but no exact
-  span.
+  (reference links resolved, escapes honored, autolinks/images handled), which carries
+  no span by design. chopdiff recovers each exact `[start, end)` by reconciling the
+  ordered identities with the name-tagged atomic spans from
+  `flowmark.atomic_spans.iter_atomic_spans` (`markdown_link` / `autolink` / `bare_url`);
+  reference links keep identity but no exact span.
 - `link → sentence` via `sentence_at_offset(link.span[0])`.
 
 ## 9. Derived Views and Rollups
 
-All calculated over the node table; nothing stores counts. The surface is **one general
-query primitive, no blessed per-kind rollups** (DR-4):
+All calculated over the node table; nothing stores counts.
+The surface is **one general query primitive, no blessed per-kind rollups** (DR-4):
 
 ```python
 collect(*, kinds=None, where=None, recursive=False, inline=False) -> list[Node]
 ```
 
 at document / section / block scope (`dg`, `dg.section(id)`, `dg.node(id)`). `kinds=`
-selects by node kind (the typed common case); `where=` is a `Node -> bool` predicate escape
-hatch; `recursive` descends into children; `inline` includes inline nodes. It returns
-**nodes** (each with `span`, `attrs`, edges). **Counts, values, and groupings are standard
-Python** over the result, documented with worked examples, not separate methods:
+selects by node kind (the typed common case); `where=` is a `Node -> bool` predicate
+escape hatch; `recursive` descends into children; `inline` includes inline nodes.
+It returns **nodes** (each with `span`, `attrs`, edges).
+**Counts, values, and groupings are standard Python** over the result, documented with
+worked examples, not separate methods:
 
 ```python
 dg.collect(kinds={NodeKind.table}, recursive=True)        # the tables (values + spans)
@@ -311,23 +410,27 @@ Counter(n.kind for n in dg.collect(recursive=True))       # tally by kind
 dg.section(s3).collect(kinds={NodeKind.link}, recursive=True)   # links in section 3
 ```
 
-Slice-by-block-type, per-section rollups, and element rollups are all expressions of this
-one primitive; relationships are node edges. There are no `tables()`/`code_blocks()`
-shortcuts to maintain. (The v0.4.0 `block_type_counts()` convenience accessors are
-superseded by `collect()`; see §14.)
+Slice-by-block-type, per-section rollups, and element rollups are all expressions of
+this one primitive; relationships are node edges.
+There are no `tables()`/`code_blocks()` shortcuts to maintain.
+(The v0.4.0 `block_type_counts()` convenience accessors are superseded by `collect()`;
+see §14.)
 
 **Query vs. partition; do not conflate.** `collect()` is a *query*: it gathers matching
-nodes and the results may **overlap** their containers (a table nested in a blockquote is
-returned by `collect(kinds={table}, recursive=True)` alongside the blockquote). That is
-correct for counting/gathering. The base-block list (§6) is a *partition*: a complete,
-ordered, **non-overlapping** cover for linear processing. Use `collect()` to ask "how many
-/ which"; use `base_blocks()` to iterate the document's content units.
+nodes and the results may **overlap** their containers (a table nested in a blockquote
+is returned by `collect(kinds={table}, recursive=True)` alongside the blockquote).
+That is correct for counting/gathering.
+The base-block list (§6) is a *partition*: a complete, ordered, **non-overlapping**
+cover for linear processing.
+Use `collect()` to ask “how many / which”; use `base_blocks()` to iterate the document’s
+content units.
 
 ## 10. DocGraph: The Serialized Projection
 
-`DocGraph` is the JSON contract derived from `TextDoc` (DR-1, DR-2), authored as Pydantic
-models that emit a JSON Schema (DR-3). Boring and parser-agnostic: no marko/Python class
-names in stable fields. Shape (abbreviated):
+`DocGraph` is the JSON contract derived from `TextDoc` (DR-1, DR-2), authored as
+Pydantic models that emit a JSON Schema (DR-3). Boring and parser-agnostic: no
+marko/Python class names in stable fields.
+Shape (abbreviated):
 
 ```
 DocGraph = {
@@ -339,8 +442,9 @@ DocGraph = {
 }
 ```
 
-`TextDoc.graph(*, include=..., detail=...)` builds/serializes it. **What is built and
-serialized is controlled by two composable axes**, not a fixed ladder (DR-5):
+`TextDoc.graph(*, include=..., detail=...)` builds/serializes it.
+**What is built and serialized is controlled by two composable axes**, not a fixed
+ladder (DR-5):
 
 ```python
 graph()                                                  # default layers, structural core
@@ -350,20 +454,24 @@ graph(include={Layer.markdown}, detail={Detail.text, Detail.inline})  # + node t
 
 - **`include` is a set of `Layer`s:** the parse dimensions of §3: `textual`, `markdown`,
   `document`, `synthetic`, later `annotations`/`layout`. Enabling a layer builds and
-  serializes its nodes/views; enabling `document` auto-enables its dependency `markdown`.
+  serializes its nodes/views; enabling `document` auto-enables its dependency
+  `markdown`.
 - **`detail` is a small set of payload sub-options:** `text` (per-node source text),
-  `inline` (inline nodes), `tokens`, derived coords, controlling richness *within* enabled
-  layers.
+  `inline` (inline nodes), `tokens`, derived coords, controlling richness *within*
+  enabled layers.
 
-The structural core (node table, `layer`, and spans) is always present. Presets are
-caller-defined `frozenset`s, documented as examples. A new parse dimension is one additive
-`Layer`; a new payload category is one additive `Detail`, never a refactor. (One vocabulary:
-the earlier mixed `Layer` enum was split into `Layer` and `Detail` per E9; see the plan's DR-5.)
+The structural core (node table, `layer`, and spans) is always present.
+Presets are caller-defined `frozenset`s, documented as examples.
+A new parse dimension is one additive `Layer`; a new payload category is one additive
+`Detail`, never a refactor.
+(One vocabulary: the earlier mixed `Layer` enum was split into `Layer` and `Detail` per
+E9; see the plan’s DR-5.)
 
 ## 11. SpanRef and Annotations
 
-`SpanRef` is the one span-reference type used for addressing a piece of the document from
-source, parsed model, and rendered output (DR-6). It carries two coordinated span kinds:
+`SpanRef` is the one span-reference type used for addressing a piece of the document
+from source, parsed model, and rendered output (DR-6). It carries two coordinated span
+kinds:
 
 ```
 SpanRef = {
@@ -374,82 +482,117 @@ SpanRef = {
 
 - **Quote canonical, offset a hint.** Every mature annotation system (W3C `oa:Choice`,
   Hypothesis) treats the text quote as the durable anchor and offsets as accelerators,
-  because the quote survives edits and re-anchors fuzzily while offsets shift. Within one
-  parse the offset is exact (the fast path); across edits the quote recovers the target.
-- **Resolution.** model→source is total (a node fills both span and quote); source→model is
-  exact fast-path then quote fuzzy re-anchor, updating offsets.
-- **Persistence** is quote-canonical and source-grounded; an in-memory `node_id` handle is
-  never persisted.
+  because the quote survives edits and re-anchors fuzzily while offsets shift.
+  Within one parse the offset is exact (the fast path); across edits the quote recovers
+  the target.
+- **Resolution.** model→source is total (a node fills both span and quote); source→model
+  is exact fast-path then quote fuzzy re-anchor, updating offsets.
+- **Persistence** is quote-canonical and source-grounded; an in-memory `node_id` handle
+  is never persisted.
 - **Chrome URL Text Fragment convertible:** the quote maps to
   `#:~:text=[prefix-,]exact[,-suffix]` (a lossy projection: prose, word-boundary,
   case-insensitive), generated on demand, never stored.
 - **Deferred:** an XPath/DOM `structural_path` and a CRDT `anchor` slot, added only on a
   concrete need.
 
-Annotations are a **stand-off layer**: parsed structure (sections, blocks, links) and added
-structure (summaries, notes, suggestions) are the same kind of thing: typed layers of
-`SpanRef`-targeted records over immutable source. **The annotation layer is a later phase**
-and is expected to be revisited and refined once v1 is in use; v1 fixes the `SpanRef`
-contract (at least as expressive as the Chrome-style `exact`+`prefix`/`suffix` floor) so the
-node model, schema, and editor bridge are designed around it.
+Annotations are a **stand-off layer**: parsed structure (sections, blocks, links) and
+added structure (summaries, notes, suggestions) are the same kind of thing: typed layers
+of `SpanRef`-targeted records over immutable source.
+**The annotation layer is a later phase** and is expected to be revisited and refined
+once v1 is in use; v1 fixes the `SpanRef` contract (at least as expressive as the
+Chrome-style `exact`+`prefix`/`suffix` floor) so the node model, schema, and editor
+bridge are designed around it.
 
-Background, syntaxes, and the syntactic-vs-quoted trade-offs are surveyed (with citations)
-in
+Background, syntaxes, and the syntactic-vs-quoted trade-offs are surveyed (with
+citations) in
 [`research-2026-05-30-span-references.md`](project/research/research-2026-05-30-span-references.md).
 
 ## 12. Editing and Serialization
 
 `Sentence.text` is the editable content: edits change what `reassemble()` produces while
 the fixed source references (`original_text`, `offsets`, cached `block_type`) keep
-describing the original. So `TextDoc` doubles as an editable model: modify units, then
-`reassemble()` to serialize a new document (optionally normalized by flowmark). The
-diff/sliding-window/wordtok machinery operates on this editing view unchanged.
+describing the original.
+So `TextDoc` doubles as an editable model: modify units, then `reassemble()` to
+serialize a new document (optionally normalized by flowmark).
+The diff/sliding-window/wordtok machinery operates on this editing view unchanged.
 
-The structural node table is a pure function of the immutable `source_text` (sentence edits
-touch the editing view, not `source_text`), so it and its derived views are lazily cached;
-the operative contract is "do not reassign `source_text` after parse." Edit by editing the
-`TextDoc`/source and re-deriving `DocGraph`; an editor bridge resolves annotations through
-`SpanRef`. Render helpers emit `data-node-id` / `data-source-span` so a rendered selection
-resolves to a node and thence to source.
+The structural node table is a pure function of the immutable `source_text` (sentence
+edits touch the editing view, not `source_text`), so it and its derived views are lazily
+cached; the operative contract is “do not reassign `source_text` after parse.”
+Edit by editing the `TextDoc`/source and re-deriving `DocGraph`; an editor bridge
+resolves annotations through `SpanRef`. Render helpers emit `data-node-id` /
+`data-source-span` so a rendered selection resolves to a node and thence to source.
 
 ## 13. Invariants and Non-Goals
 
-Invariants: offset-anchored (code points); node ids stable within a parse; one canonical
-form (node table) with derived views (no duplicated content, no stored counts); references
-are quote-canonical; additive (existing behavior preserved).
+Invariants: offset-anchored (code points), the source + offset space being the canonical
+substrate (P1); node ids stable within a parse; derived views over one shared parse (no
+duplicated content, no stored counts), the node table among them; references are
+quote-canonical; additive (existing behavior preserved).
 
-Non-goals: a parallel runtime `BlockDoc`/`SectionDoc`/`FlexDoc` Python model (DocGraph is
-a projection, not a competing editable model); blessed per-kind rollups or fixed detail
-levels; DOM/XPath/CSS selectors in `SpanRef` (plain-text-first); CommonMark/GFM rendering
-(flowmark covers normalization); stored cross-layer edges (cross-layer relationships are
-offset-containment queries, §3); exact provider-keyed token counts (`estimate_tokens` is a
-heuristic); a thread-safety layer.
+Non-goals: a parallel runtime `BlockDoc`/`SectionDoc`/`FlexDoc` Python model (DocGraph
+is a projection, not a competing editable model); blessed per-kind rollups or fixed
+detail levels; DOM/XPath/CSS selectors in `SpanRef` (plain-text-first); CommonMark/GFM
+rendering (flowmark covers normalization); stored cross-layer edges (cross-layer
+relationships are offset-containment queries, §3); exact provider-keyed token counts
+(`estimate_tokens` is a heuristic); a thread-safety layer.
 
-**Later phases, not non-goals (E9).** The **synthetic layer**, re-expressing today's
-`TextNode` tag chunking (a small defined set of marker tags, today `<div>`/`<span>`) as a layer
-keyed into the node table, and **cross-layer structural edits** (move/wrap/splice anchored on
-`SpanRef`, generalizing `div_insert_wrapped`) are deferred phases, not excluded. `TextNode`
-stays as-is meanwhile.
-The annotation, operation, provenance, and layout layers are likewise schema-reserved and
-built later. The Phase-1 hooks (the `layer` field, offset-containment `collect()`,
+**Later phases, not non-goals (E9).** The **synthetic layer**, re-expressing today’s
+`TextNode` tag chunking (a small defined set of marker tags, today `<div>`/`<span>`) as
+a layer keyed into the node table, and **cross-layer structural edits**
+(move/wrap/splice anchored on `SpanRef`, generalizing `div_insert_wrapped`) are deferred
+phases, not excluded.
+`TextNode` stays as-is meanwhile.
+The annotation, operation, provenance, and layout layers are likewise schema-reserved
+and built later. The Phase-1 hooks (the `layer` field, offset-containment `collect()`,
 `SpanRef`-anchored edits) keep these a small lift rather than a redesign.
+
+### Pitfalls and Key Decisions
+
+Non-obvious choices, each grounded in a principle:
+
+- **The shared offset space — not the node table — is the canonical substrate** (P1).
+  The node table is one projection (the id-addressed, layer-tagged,
+  serialization-friendly one); it is built *from* the parses, and
+  `blocks()`/`sections()`/`links()` derive from the same memoized parse rather than from
+  the table’s id space.
+  “Single canonical form” holds at the parse + offset space.
+- **Cross-layer overlap is expected** (P3). The same logical paragraph appears as
+  distinct nodes in distinct layers (a `markdown` block node and a `textual` paragraph
+  node over the same span), so a query that does not restrict `layer` returns both.
+  This is honest, not a bug; scope with `collect(layer=…)`.
+- **Tight vs. loose lists are structurally identical** (P7, P12). Density is
+  `Block.tight` metadata only and never enters a tally.
+- **Base blocks decompose lists recursively** to `item_partition_depth` (default 6);
+  blockquotes are always atomic (P13).
+- **Fast/approximate sentence segmentation is accepted** (P16): the regex splitter
+  avoids a Spacy dependency; offsets stay exact via the span-aware splitter.
+- **Fast/approximate token sizing is accepted** (P16): `estimate_tokens` is a heuristic,
+  not provider-keyed.
+- **Reference links and other unlocatable identities carry `span=None`** and are
+  excluded from offset-scoped rollups (e.g. `Section.links()`), since they cannot be
+  attributed by offset.
+- **Offsets are Unicode code points** (P1); byte/UTF-16 are derived on demand, never
+  canonical.
+- **Round-trip is Markdown-object-exact, not byte-exact** (P11), except byte-exact via
+  retained offsets or after Flowmark normalization — two distinct equivalence levels.
 
 ## 14. Implementation Status
 
-- **Shipped in v0.4.0:** exact spans; the opt-in structural block tree `blocks()` (boundaries
-  and spans from flowmark, no regex scanner); sections/TOC/size rollups; inline-link rollups
-  and link-aware sentences; `ordered_list`/density-invariant lists; per-section blocks; and
-  **top-level** `block_type_counts()`.
+- **Shipped in v0.4.0:** exact spans; the opt-in structural block tree `blocks()`
+  (boundaries and spans from flowmark, no regex scanner); sections/TOC/size rollups;
+  inline-link rollups and link-aware sentences; `ordered_list`/density-invariant lists;
+  per-section blocks; and **top-level** `block_type_counts()`.
 - **Implemented (post-v0.4.0):** the recursive node table (containers fully populate
-  children, including blockquote and list-item block children); `base_blocks()` sequential
-  partition with its non-overlapping cover invariant; the single `collect()` primitive
-  (superseding `block_type_counts()`; migration:
+  children, including blockquote and list-item block children); `base_blocks()`
+  sequential partition with its non-overlapping cover invariant; the single `collect()`
+  primitive (superseding `block_type_counts()`; migration:
   `Counter(n.kind for n in doc.graph().collect(...))`); composable `include` layers and
   `detail` payload options; the `DocGraph` Pydantic schema ("DocGraph/v0.1"); and the
   `SpanRef` contract with exact resolution (fuzzy re-anchor wired behind it).
-- **In progress:** annotation layer, synthetic layer (re-expressing `TextNode` tag chunking
-  as a layer), cross-layer structural edits, and operation/provenance/layout layers.
-  Tracked by epic `chopdiff-8q8q`; sequenced in
+- **In progress:** annotation layer, synthetic layer (re-expressing `TextNode` tag
+  chunking as a layer), cross-layer structural edits, and operation/provenance/layout
+  layers. Tracked by epic `chopdiff-8q8q`; sequenced in
   [`plan-2026-05-29-unified-document-model.md`](project/specs/active/plan-2026-05-29-unified-document-model.md).
 
 ## 15. References
@@ -471,4 +614,5 @@ built later. The Phase-1 hooks (the `layer` field, offset-containment `collect()
 
 * * *
 
-*This document follows the tbd [writing style guidelines](https://github.com/jlevy/tbd).*
+*This document follows the tbd
+[writing style guidelines](https://github.com/jlevy/tbd).*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "regex>=2024.11.6",
     "selectolax>=0.3.32",
     "pydantic>=2.13.4",
+    "frontmatter-format>=0.3.0",
 ]
 
 [project.optional-dependencies]

--- a/src/chopdiff/docs/__init__.py
+++ b/src/chopdiff/docs/__init__.py
@@ -4,6 +4,12 @@ from chopdiff.docs.base_blocks import BaseBlock, base_blocks
 from chopdiff.docs.block_tree import Block
 from chopdiff.docs.block_types import BlockType
 from chopdiff.docs.collect import collect
+from chopdiff.docs.debug import (
+    doc_graph_yaml,
+    doc_report,
+    doc_report_data,
+    dump_views,
+)
 from chopdiff.docs.doc_graph import (
     Detail,
     DocGraph,
@@ -124,6 +130,10 @@ __all__ = [
     "BaseBlock",
     "base_blocks",
     "collect",
+    "doc_report",
+    "doc_report_data",
+    "doc_graph_yaml",
+    "dump_views",
     "LAYER_NESTING",
     "Layer",
     "NestingGuarantee",

--- a/src/chopdiff/docs/base_blocks.py
+++ b/src/chopdiff/docs/base_blocks.py
@@ -2,14 +2,22 @@
 Sequential base-block partition of a Markdown document.
 
 A base block is a unit of the flat, depth-annotated partition described in
-textdoc-spec section 6. The partition is ordered by source position, spans are
-non-overlapping, and it is a complete cover of the document. Reassembling the
-base blocks in order reproduces the document exactly except for normalized
-paragraph-break whitespace (runs of blank lines between blocks).
+textdoc-spec section 6. The partition is ordered by source position, its spans are
+non-overlapping, and together they cover every non-whitespace character of the
+document exactly once (the gaps are inter-block and structural whitespace). It is the
+view for block-by-block processing and resequencing.
+
+Each base block retains its exact `source_span`, so exact source reconstruction is
+available by slicing the source at those spans (or via the structural `blocks()` tree).
+Reassembling the rendered base-block *text* is lossy for list-item continuation content:
+list markers and continuation indentation are whitespace outside the trimmed spans, so a
+naive text concatenation normalizes them. Reconstruct from offsets when exactness matters.
 
 Leaf/atomic blocks (heading, paragraph, table, code, thematic_break, html, and
-a whole blockquote) are each one base block. Lists decompose so each list item
-at every nesting level is its own base block with increasing depth.
+a whole blockquote) are each one base block. Lists decompose: each list item at every
+nesting level is its own base block with increasing depth, and a list item's continuation
+content (paragraphs after or between nested sublists) is emitted with its own real block
+type at the item's depth — never relabeled `list_item`.
 """
 
 from __future__ import annotations
@@ -60,9 +68,10 @@ def base_blocks(text: str, *, item_partition_depth: int = 6) -> list[BaseBlock]:
 
     Blockquotes are always one base block regardless of depth.
 
-    Invariants: the result is ordered by source position, spans are non-overlapping,
-    and the partition is a complete cover (reassembling reproduces the document
-    except for normalized paragraph-break whitespace between blocks).
+    Invariants: the result is ordered by source position, spans are non-overlapping, and
+    together they cover every non-whitespace character exactly once. Exact source
+    reconstruction is via each block's `source_span` (not by concatenating block text;
+    see the module docstring for the continuation-content caveat).
     """
     blocks = parse_blocks(text)
     result: list[BaseBlock] = []
@@ -112,48 +121,43 @@ def _emit_list_item(
 ) -> None:
     """
     Emit a list item as base blocks. A leaf item (no nested lists, or at the depth
-    limit) emits its full span as one block. Otherwise the item is walked in source
-    order as alternating own-content segments and nested lists: each maximal run of
-    non-list content (before, between, or after sublists) becomes an own-content base
-    block at `depth`, and each nested list's items recurse at `depth + 1`. This keeps
-    the partition a complete, non-overlapping cover — content that follows or sits
-    between sublists is not dropped.
+    limit) emits its full span as one block. Otherwise the item decomposes, in source
+    order, into:
+
+    - one `list_item` head block spanning from the item start (the list marker) through
+      its lead content up to the first nested sublist, at `depth`;
+    - each nested sublist's items, recursed at `depth + 1`;
+    - each *continuation* block (content after or between sublists) emitted with its own
+      real block type (e.g. `paragraph`), at `depth`.
+
+    Continuation content keeps its real type rather than being mislabeled `list_item`, so
+    a consumer can tell a continuation paragraph apart from an independent list item.
+    Spans are non-overlapping and cover every non-whitespace character. Exact source
+    reconstruction is via each block's `source_span` (or the structural `blocks()` tree),
+    not by concatenating base-block text: list-marker and continuation indentation are
+    whitespace outside the trimmed spans.
     """
-    nested_lists = sorted(
-        (c for c in item.children if c.type in _LIST_TYPES), key=lambda c: c.span[0]
-    )
+    nested_lists = [c for c in item.children if c.type in _LIST_TYPES]
     at_depth_limit = max_depth != -1 and current_nesting >= max_depth
 
     if not nested_lists or at_depth_limit:
         out.append(BaseBlock(block=item, depth=depth))
         return
 
-    cursor = item.span[0]
-    for nested in nested_lists:
-        _emit_own_segment(text, item, cursor, nested.span[0], depth, out)
-        for nested_item in nested.children:
-            _emit_list_item(text, nested_item, depth + 1, max_depth, current_nesting + 1, out)
-        cursor = nested.span[1]
-    _emit_own_segment(text, item, cursor, item.span[1], depth, out)
+    # Head: the marker plus lead content up to the first nested sublist, typed list_item.
+    first_nested_start = min(c.span[0] for c in nested_lists)
+    head_end = first_nested_start
+    while head_end > item.span[0] and text[head_end - 1].isspace():
+        head_end -= 1
+    if head_end > item.span[0]:
+        head = Block(type=item.type, span=(item.span[0], head_end), children=[], tight=item.tight)
+        out.append(BaseBlock(block=head, depth=depth))
 
-
-def _emit_own_segment(
-    text: str,
-    item: Block,
-    start: int,
-    end: int,
-    depth: int,
-    out: list[BaseBlock],
-) -> None:
-    """
-    Emit one own-content segment of a list item (the span between two nested lists,
-    or before the first / after the last), trimmed of surrounding whitespace and
-    skipped if empty. The segment keeps the item's type and `tight` flag.
-    """
-    while start < end and text[start].isspace():
-        start += 1
-    while end > start and text[end - 1].isspace():
-        end -= 1
-    if start < end:
-        own_block = Block(type=item.type, span=(start, end), children=[], tight=item.tight)
-        out.append(BaseBlock(block=own_block, depth=depth))
+    # Then, in source order: recurse into each sublist; emit each continuation block
+    # (any non-list child past the head) with its own real type.
+    for child in item.children:
+        if child.type in _LIST_TYPES:
+            for nested_item in child.children:
+                _emit_list_item(text, nested_item, depth + 1, max_depth, current_nesting + 1, out)
+        elif child.span[1] > head_end:
+            out.append(BaseBlock(block=child, depth=depth))

--- a/src/chopdiff/docs/base_blocks.py
+++ b/src/chopdiff/docs/base_blocks.py
@@ -111,36 +111,49 @@ def _emit_list_item(
     out: list[BaseBlock],
 ) -> None:
     """
-    Emit a list item as a base block. If the item contains nested lists and we
-    have not exceeded `max_depth`, emit a block whose span covers only the item's
-    OWN content (from item start to the start of its first nested list child,
-    with trailing whitespace trimmed), then recurse into each nested list at
-    depth+1. A leaf list item (no nested lists) emits its full span.
+    Emit a list item as base blocks. A leaf item (no nested lists, or at the depth
+    limit) emits its full span as one block. Otherwise the item is walked in source
+    order as alternating own-content segments and nested lists: each maximal run of
+    non-list content (before, between, or after sublists) becomes an own-content base
+    block at `depth`, and each nested list's items recurse at `depth + 1`. This keeps
+    the partition a complete, non-overlapping cover — content that follows or sits
+    between sublists is not dropped.
     """
-    nested_lists = [c for c in item.children if c.type in _LIST_TYPES]
+    nested_lists = sorted(
+        (c for c in item.children if c.type in _LIST_TYPES), key=lambda c: c.span[0]
+    )
     at_depth_limit = max_depth != -1 and current_nesting >= max_depth
 
     if not nested_lists or at_depth_limit:
         out.append(BaseBlock(block=item, depth=depth))
-    else:
-        # The item's own content runs from item start to the start of its first
-        # nested list child. Trim trailing whitespace from the source so the span
-        # covers only meaningful content.
-        first_nested_start = min(c.span[0] for c in nested_lists)
-        own_start = item.span[0]
-        own_end = first_nested_start
-        while own_end > own_start and text[own_end - 1].isspace():
-            own_end -= 1
-        own_block = Block(
-            type=item.type,
-            span=(own_start, own_end),
-            children=[],
-            tight=item.tight,
-        )
+        return
+
+    cursor = item.span[0]
+    for nested in nested_lists:
+        _emit_own_segment(text, item, cursor, nested.span[0], depth, out)
+        for nested_item in nested.children:
+            _emit_list_item(text, nested_item, depth + 1, max_depth, current_nesting + 1, out)
+        cursor = nested.span[1]
+    _emit_own_segment(text, item, cursor, item.span[1], depth, out)
+
+
+def _emit_own_segment(
+    text: str,
+    item: Block,
+    start: int,
+    end: int,
+    depth: int,
+    out: list[BaseBlock],
+) -> None:
+    """
+    Emit one own-content segment of a list item (the span between two nested lists,
+    or before the first / after the last), trimmed of surrounding whitespace and
+    skipped if empty. The segment keeps the item's type and `tight` flag.
+    """
+    while start < end and text[start].isspace():
+        start += 1
+    while end > start and text[end - 1].isspace():
+        end -= 1
+    if start < end:
+        own_block = Block(type=item.type, span=(start, end), children=[], tight=item.tight)
         out.append(BaseBlock(block=own_block, depth=depth))
-        for child in item.children:
-            if child.type in _LIST_TYPES:
-                for nested_item in child.children:
-                    _emit_list_item(
-                        text, nested_item, depth + 1, max_depth, current_nesting + 1, out
-                    )

--- a/src/chopdiff/docs/collect.py
+++ b/src/chopdiff/docs/collect.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-from chopdiff.docs.node import Node, NodeKind, NodeTable
+from chopdiff.docs.node import Layer, Node, NodeKind, NodeTable
 
 # Inline NodeKinds: elements that live inside a block.
 INLINE_KINDS: frozenset[NodeKind] = frozenset(
@@ -31,6 +31,7 @@ def collect(
     recursive: bool = False,
     inline: bool = False,
     contains: tuple[int, int] | None = None,
+    layer: set[Layer] | None = None,
 ) -> list[Node]:
     """
     Gather nodes from `table` matching the given filters, in document order.
@@ -42,7 +43,10 @@ def collect(
     scope (or roots). `inline`: when True, include inline-kind nodes; when
     False, exclude them. `contains`: an optional `(start, end)` span;
     restrict results to nodes whose `source_span` is within that span
-    (offset-containment, the cross-layer query mechanism).
+    (offset-containment, the cross-layer query mechanism). `layer`: restrict to
+    these parse layers (None = all layers); since the same span can appear as
+    nodes in several layers (e.g. a `markdown` block and a `textual` paragraph),
+    scope by `layer` to avoid cross-layer duplicates.
     """
     if scope is not None:
         candidates = _subtree_nodes(table, scope, recursive)
@@ -57,6 +61,8 @@ def collect(
     for node in candidates:
         if not inline and node.kind in INLINE_KINDS:
             continue
+        if layer is not None and node.layer not in layer:
+            continue
         if kinds is not None and node.kind not in kinds:
             continue
         if contains is not None:
@@ -70,14 +76,17 @@ def collect(
             continue
         result.append(node)
 
-    # Sort by source_span start (then by span width descending for stability)
-    # to guarantee deterministic document order.
-    result.sort(
-        key=lambda n: (
-            n.source_span[0] if n.source_span else 0,
-            -(n.source_span[1] - n.source_span[0]) if n.source_span else 0,
-        )
-    )
+    # Sort by source_span start (then by span width descending) for deterministic
+    # document order. Nodes without a span (e.g. reference links) have no position, so
+    # they sort last by id rather than colliding at offset 0 with real document-start
+    # nodes.
+    def _sort_key(n: Node) -> tuple[int, int, int, str]:
+        if n.source_span is None:
+            return (1, 0, 0, n.id)
+        start, end = n.source_span
+        return (0, start, -(end - start), n.id)
+
+    result.sort(key=_sort_key)
     return result
 
 

--- a/src/chopdiff/docs/debug.py
+++ b/src/chopdiff/docs/debug.py
@@ -24,10 +24,10 @@ import hashlib
 from pathlib import Path
 from typing import Any
 
-from frontmatter_format import to_yaml_string
 from strif import atomic_output_file
 
 from chopdiff.docs.base_blocks import base_blocks
+from chopdiff.docs.doc_graph import clean_yaml
 from chopdiff.docs.node import NodeKind
 from chopdiff.docs.sizes import TextUnit
 from chopdiff.docs.span_ref import SpanRef, resolve
@@ -150,7 +150,7 @@ def doc_report_data(doc: TextDoc, *, item_partition_depth: int = 6) -> dict[str,
 
 def doc_report(doc: TextDoc, *, item_partition_depth: int = 6) -> str:
     """The multi-view report as clean, deterministic YAML."""
-    return to_yaml_string(doc_report_data(doc, item_partition_depth=item_partition_depth))
+    return clean_yaml(doc_report_data(doc, item_partition_depth=item_partition_depth))
 
 
 def doc_graph_yaml(doc: TextDoc) -> str:

--- a/src/chopdiff/docs/debug.py
+++ b/src/chopdiff/docs/debug.py
@@ -1,0 +1,175 @@
+"""
+Reusable developer tool for dumping a document's model views in clean, standard
+formats. Works on any `TextDoc`: use it from a REPL, a script, or the golden-test
+harness to see every projection the model derives from one source.
+
+Three views, all deterministic (the model is hermetic — node ids are a stable preorder
+counter, sha256 and token estimates are deterministic), so output is byte-stable and
+diff-friendly:
+
+- `doc_report(doc)` — a multi-view YAML report: source stats, the base-block partition
+  with a live cover check, sections/TOC, the full node table (all layers), links by
+  section, and SpanRef round-trips.
+- `doc_graph_yaml(doc)` — the `DocGraph` projection as clean YAML.
+- `dump_views(doc, dest)` — write the standard artifact set (`report.yaml`,
+  `docgraph.yaml`, `reassembled.md`) into a directory.
+
+Spans are rendered as compact `"start:end"` strings (Unicode code points), matching the
+`data-source-span` convention in `chopdiff.docs.render`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+from frontmatter_format import to_yaml_string
+from strif import atomic_output_file
+
+from chopdiff.docs.base_blocks import base_blocks
+from chopdiff.docs.node import NodeKind
+from chopdiff.docs.sizes import TextUnit
+from chopdiff.docs.span_ref import SpanRef, resolve
+from chopdiff.docs.text_doc import TextDoc
+
+# Inline kinds that carry a locatable span worth round-tripping through SpanRef.
+_LOCATABLE_INLINE = frozenset({NodeKind.link, NodeKind.image, NodeKind.code_span})
+
+
+def _span_str(span: tuple[int, int] | None) -> str | None:
+    return f"{span[0]}:{span[1]}" if span is not None else None
+
+
+def doc_report_data(doc: TextDoc, *, item_partition_depth: int = 6) -> dict[str, Any]:
+    """
+    The multi-view report as a plain (ordered) dict, ready to serialize. Captures broad
+    state rather than narrow slices, so any change to any view shows up in a diff.
+    """
+    source_text = doc.source_text or doc.reassemble()
+
+    # Base-block partition with a live complete-cover check.
+    bbs = base_blocks(source_text, item_partition_depth=item_partition_depth)
+    covered: set[int] = set()
+    for bb in bbs:
+        covered.update(range(bb.block.span[0], bb.block.span[1]))
+    uncovered = {i for i in range(len(source_text)) if not source_text[i].isspace()} - covered
+    base_block_rows = [
+        {
+            "depth": bb.depth,
+            "type": bb.block.type.value,
+            "span": _span_str(bb.block.span),
+            "text": source_text[bb.block.span[0] : bb.block.span[1]],
+        }
+        for bb in bbs
+    ]
+
+    # Sections / TOC, flattened in document order with rolled-up sizes.
+    section_rows: list[dict[str, Any]] = []
+
+    def _walk(sections: list[Any]) -> None:
+        for sec in sections:
+            section_rows.append(
+                {
+                    "level": sec.level,
+                    "title": sec.title,
+                    "span": _span_str(sec.span),
+                    "words": sec.size(TextUnit.words),
+                }
+            )
+            _walk(sec.children)
+
+    _walk(doc.sections())
+
+    # Full node table, every layer, in id order.
+    table = doc.node_table()
+    node_rows = [
+        {
+            "id": nid,
+            "layer": n.layer.value,
+            "kind": n.kind.value,
+            "span": _span_str(n.source_span),
+            "parent": n.parent,
+            "attrs": dict(n.attrs) if n.attrs else None,
+        }
+        for nid, n in table.nodes.items()
+    ]
+
+    # Links (and images) with the model's own section attribution.
+    link_rows: list[dict[str, Any]] = []
+    for n in table.nodes.values():
+        if n.kind not in (NodeKind.link, NodeKind.image):
+            continue
+        section_id = n.attrs.get("section")
+        section_title = None
+        if isinstance(section_id, str) and section_id in table.nodes:
+            section_title = table.nodes[section_id].attrs.get("title")
+        link_rows.append(
+            {
+                "kind": n.kind.value,
+                "text": n.attrs.get("text"),
+                "url": n.attrs.get("url"),
+                "span": _span_str(n.source_span),
+                "section": section_title,
+            }
+        )
+
+    # SpanRef round-trips: persist quote-canonical, then re-resolve against the source.
+    spanref_rows: list[dict[str, Any]] = []
+    for n in table.nodes.values():
+        if n.kind not in _LOCATABLE_INLINE or n.source_span is None:
+            continue
+        ref = SpanRef.from_node(n, source_text)
+        resolved = resolve(ref.to_persisted(), source_text)
+        spanref_rows.append(
+            {
+                "id": n.id,
+                "exact": ref.exact,
+                "resolved": _span_str(resolved),
+                "ok": resolved == n.source_span,
+            }
+        )
+
+    return {
+        "source": {
+            "sha256": hashlib.sha256(source_text.encode("utf-8")).hexdigest(),
+            "length": len(source_text),
+            "size_summary": doc.size_summary(),
+        },
+        "base_blocks": {
+            "cover_ok": not uncovered,
+            "uncovered_nonspace": len(uncovered),
+            "blocks": base_block_rows,
+        },
+        "sections": section_rows,
+        "node_table": node_rows,
+        "links": link_rows,
+        "spanrefs": spanref_rows,
+    }
+
+
+def doc_report(doc: TextDoc, *, item_partition_depth: int = 6) -> str:
+    """The multi-view report as clean, deterministic YAML."""
+    return to_yaml_string(doc_report_data(doc, item_partition_depth=item_partition_depth))
+
+
+def doc_graph_yaml(doc: TextDoc) -> str:
+    """The default `DocGraph` projection (markdown + document layers) as clean YAML."""
+    return doc.graph().to_yaml()
+
+
+def dump_views(doc: TextDoc, dest: Path | str, *, item_partition_depth: int = 6) -> None:
+    """
+    Write the standard artifact set for `doc` into directory `dest`: `report.yaml`,
+    `docgraph.yaml`, and `reassembled.md`. Files are written atomically.
+    """
+    dest = Path(dest)
+    dest.mkdir(parents=True, exist_ok=True)
+    artifacts = {
+        "report.yaml": doc_report(doc, item_partition_depth=item_partition_depth),
+        "docgraph.yaml": doc_graph_yaml(doc),
+        "reassembled.md": doc.reassemble(),
+    }
+    for name, content in artifacts.items():
+        with atomic_output_file(dest / name) as tmp:
+            tmp.write_text(content, encoding="utf-8")

--- a/src/chopdiff/docs/doc_graph.py
+++ b/src/chopdiff/docs/doc_graph.py
@@ -12,13 +12,30 @@ from __future__ import annotations
 
 import hashlib
 from enum import StrEnum
+from io import StringIO
 from typing import Literal
 
-from frontmatter_format import to_yaml_string
+from frontmatter_format import new_yaml
 from pydantic import BaseModel, ConfigDict, Field
 
 from chopdiff.docs.collect import INLINE_KINDS
 from chopdiff.docs.node import Layer, Node, NodeKind, NodeTable
+
+
+def _is_empty(value: object) -> bool:
+    return value is None or value == {} or value == []
+
+
+def clean_yaml(value: object) -> str:
+    """
+    Dump a plain value to clean, deterministic block-style YAML: `|` block scalars for
+    multi-line strings, field order preserved, and `None`/empty mappings/lists
+    suppressed. Shared by `DocGraph.to_yaml` and the `chopdiff.docs.debug` report so both
+    have identical formatting.
+    """
+    stream = StringIO()
+    new_yaml(suppress_vals=_is_empty, typ="rt").dump(value, stream)
+    return stream.getvalue()
 
 
 class Detail(StrEnum):
@@ -110,10 +127,11 @@ class DocGraph(BaseModel):
         """
         Serialize to clean, deterministic YAML: the same model as `model_dump_json`
         but in block style with `|` block scalars for multi-line text, field order
-        preserved, and `None`/empty values suppressed. JSON stays the canonical wire
-        form; YAML is the human/golden form (see `chopdiff.docs.debug`).
+        preserved, and `None`/empty mappings and lists suppressed (so leaf nodes carry
+        no `children: []` and reserved layers do not appear when empty). JSON stays the
+        canonical wire form; YAML is the human/golden form (see `chopdiff.docs.debug`).
         """
-        return to_yaml_string(self.model_dump(by_alias=True))
+        return clean_yaml(self.model_dump(by_alias=True))
 
 
 # Default layers included when none are specified.

--- a/src/chopdiff/docs/doc_graph.py
+++ b/src/chopdiff/docs/doc_graph.py
@@ -14,6 +14,7 @@ import hashlib
 from enum import StrEnum
 from typing import Literal
 
+from frontmatter_format import to_yaml_string
 from pydantic import BaseModel, ConfigDict, Field
 
 from chopdiff.docs.collect import INLINE_KINDS
@@ -104,6 +105,15 @@ class DocGraph(BaseModel):
     annotations: list[object] = Field(default_factory=list)
     layout: list[object] = Field(default_factory=list)
     provenance: list[object] = Field(default_factory=list)
+
+    def to_yaml(self) -> str:
+        """
+        Serialize to clean, deterministic YAML: the same model as `model_dump_json`
+        but in block style with `|` block scalars for multi-line text, field order
+        preserved, and `None`/empty values suppressed. JSON stays the canonical wire
+        form; YAML is the human/golden form (see `chopdiff.docs.debug`).
+        """
+        return to_yaml_string(self.model_dump(by_alias=True))
 
 
 # Default layers included when none are specified.

--- a/src/chopdiff/docs/node_table.py
+++ b/src/chopdiff/docs/node_table.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING
 
 from flowmark.atomic_spans import iter_atomic_spans
 
-from chopdiff.docs.block_tree import Block, parse_blocks
+from chopdiff.docs.block_tree import Block
 from chopdiff.docs.node import Layer, Node, NodeKind, NodeTable
 
 if TYPE_CHECKING:
@@ -189,21 +189,14 @@ def _build_inline_nodes(
             if sent_nid:
                 attrs["sentence"] = sent_nid
 
-            # Distinguish images from links: `!` immediately precedes the `[`.
-            kind = NodeKind.link
-            start = link.span[0]
-            if start > 0 and source_text[start - 1] == "!":
-                kind = NodeKind.image
-                adjusted_span: tuple[int, int] = (start - 1, link.span[1])
-            else:
-                adjusted_span = link.span
-
+            # `doc.links()` (extract_links) yields links only, never images, so every
+            # span here is a link. Images come from the atomic-span pass below.
             node = Node(
                 id=nid,
-                kind=kind,
+                kind=NodeKind.link,
                 layer=Layer.markdown,
                 parent=parent,
-                source_span=adjusted_span,
+                source_span=link.span,
                 attrs=attrs,
             )
             all_nodes[nid] = node
@@ -343,8 +336,9 @@ def build_node_table(doc: TextDoc) -> NodeTable:
     roots: list[str] = []
     counter: list[int] = [1]
 
-    # Markdown layer: structural blocks.
-    blocks = parse_blocks(source_text)
+    # Markdown layer: structural blocks. Reuse the doc's cached structural parse so the
+    # node table and the `blocks()` view share one parse over the shared offset space.
+    blocks = doc.blocks()
     root_ids = _build_markdown_nodes(blocks, source_text, None, counter, nodes)
     roots.extend(root_ids)
 

--- a/src/chopdiff/docs/text_doc.py
+++ b/src/chopdiff/docs/text_doc.py
@@ -15,6 +15,7 @@ from funlog import tally_calls
 from marko.block import BlankLine, Heading, SetextHeading
 from typing_extensions import override
 
+from chopdiff.docs.base_blocks import BaseBlock, base_blocks
 from chopdiff.docs.block_tree import Block, parse_blocks
 from chopdiff.docs.block_types import BlockType, block_type_for
 from chopdiff.docs.collect import collect as _collect
@@ -484,6 +485,8 @@ class TextDoc:
     _cached_node_table: NodeTable | None = field(
         default=None, init=False, compare=False, repr=False
     )
+    _cached_blocks: list[Block] | None = field(default=None, init=False, compare=False, repr=False)
+    _cached_links: list[Link] | None = field(default=None, init=False, compare=False, repr=False)
 
     def node_table(self) -> NodeTable:
         """
@@ -602,7 +605,12 @@ class TextDoc:
                     stack[-1].content.append(para)
                 continue
             section = Section(
-                heading=para, level=level, content=[], children=[], source_text=source_text
+                heading=para,
+                level=level,
+                content=[],
+                children=[],
+                source_text=source_text,
+                _doc=self,
             )
             while stack and stack[-1].level >= level:
                 stack.pop()
@@ -617,10 +625,12 @@ class TextDoc:
         """
         All links in the document, in document order. Parsed from `source_text` once so
         that reference-style links (`[text][ref]` with `[ref]: url` in a separate block)
-        resolve correctly. See `Link`.
+        resolve correctly. Lazily cached so per-section link rollups share one parse. See
+        `Link`.
         """
-        text = self.source_text or self.reassemble()
-        return _block_links(text, 0)
+        if self._cached_links is None:
+            self._cached_links = _block_links(self.source_text or self.reassemble(), 0)
+        return self._cached_links
 
     def blocks(self) -> list[Block]:
         """
@@ -629,8 +639,27 @@ class TextDoc:
         internal blank lines) and decomposes a tight list into `list_item`s with nested
         sublists. Parsed from `source_text` (or the reassembled text if absent). See
         `chopdiff.docs.block_tree`.
+
+        Lazily cached on the immutable `source_text` (sentence edits touch the editing
+        view, not `source_text`), so derived views (`sections()`, the node table) can
+        share one parse rather than re-parsing.
         """
-        return parse_blocks(self.source_text or self.reassemble())
+        if self._cached_blocks is None:
+            self._cached_blocks = parse_blocks(self.source_text or self.reassemble())
+        return self._cached_blocks
+
+    def base_blocks(self, *, item_partition_depth: int = 6) -> list[BaseBlock]:
+        """
+        The flat, depth-annotated sequential base-block partition of the document: a
+        complete, ordered, non-overlapping cover whose reassembly reproduces the source
+        (except normalized paragraph-break whitespace). A thin method over the
+        `chopdiff.docs.base_blocks.base_blocks` free function; see it for the
+        `item_partition_depth` semantics. Distinct from `blocks()`, which is the
+        recursive structural tree (a query view, not a partition).
+        """
+        return base_blocks(
+            self.source_text or self.reassemble(), item_partition_depth=item_partition_depth
+        )
 
     def block_type_counts(self) -> Counter[BlockType]:
         """
@@ -931,6 +960,7 @@ class TextDoc:
         recursive: bool = False,
         inline: bool = False,
         contains: tuple[int, int] | None = None,
+        layer: set[Layer] | None = None,
     ) -> list[Node]:
         """
         Convenience that calls `collect()` over `self.node_table()`. See
@@ -944,6 +974,7 @@ class TextDoc:
             recursive=recursive,
             inline=inline,
             contains=contains,
+            layer=layer,
         )
 
     def graph(
@@ -989,6 +1020,21 @@ class Section:
     content: list[Paragraph]
     children: list[Section]
     source_text: str = ""
+    _doc: TextDoc | None = field(default=None, compare=False, repr=False)
+
+    def _all_blocks(self) -> list[Block]:
+        """The whole-document structural parse, shared via the owning doc's cache when
+        available (standalone sections fall back to a direct parse)."""
+        if self._doc is not None:
+            return self._doc.blocks()
+        return parse_blocks(self.source_text)
+
+    def _all_links(self) -> list[Link]:
+        """The whole-document link list, shared via the owning doc's cache when
+        available (standalone sections fall back to a direct parse)."""
+        if self._doc is not None:
+            return self._doc.links()
+        return _block_links(self.source_text, 0)
 
     @property
     def title(self) -> str:
@@ -1008,9 +1054,7 @@ class Section:
         own = self.own_blocks()
         start, end = own[0].span[0], own[-1].span[1]
         return [
-            block
-            for block in parse_blocks(self.source_text)
-            if start <= block.span[0] and block.span[1] <= end
+            block for block in self._all_blocks() if start <= block.span[0] and block.span[1] <= end
         ]
 
     def block_type_counts(self) -> Counter[BlockType]:
@@ -1056,9 +1100,8 @@ class Section:
         by offset alone.
         """
         sec_start, sec_end = self.span
-        all_links = _block_links(self.source_text, 0)
         return [
             link
-            for link in all_links
+            for link in self._all_links()
             if link.span is not None and sec_start <= link.span[0] and link.span[1] <= sec_end
         ]

--- a/src/chopdiff/docs/text_doc.py
+++ b/src/chopdiff/docs/text_doc.py
@@ -625,12 +625,13 @@ class TextDoc:
         """
         All links in the document, in document order. Parsed from `source_text` once so
         that reference-style links (`[text][ref]` with `[ref]: url` in a separate block)
-        resolve correctly. Lazily cached so per-section link rollups share one parse. See
-        `Link`.
+        resolve correctly. Lazily cached so per-section link rollups share one parse;
+        returns a fresh shallow copy each call so mutating the result cannot poison the
+        cache (`Link` is frozen, so the shared elements are safe). See `Link`.
         """
         if self._cached_links is None:
             self._cached_links = _block_links(self.source_text or self.reassemble(), 0)
-        return self._cached_links
+        return list(self._cached_links)
 
     def blocks(self) -> list[Block]:
         """
@@ -642,11 +643,14 @@ class TextDoc:
 
         Lazily cached on the immutable `source_text` (sentence edits touch the editing
         view, not `source_text`), so derived views (`sections()`, the node table) can
-        share one parse rather than re-parsing.
+        share one parse rather than re-parsing. Returns a fresh shallow copy of the
+        cached list each call, so reordering/filtering the result cannot poison the
+        shared cache; the `Block` objects themselves are shared and must be treated as
+        read-only.
         """
         if self._cached_blocks is None:
             self._cached_blocks = parse_blocks(self.source_text or self.reassemble())
-        return self._cached_blocks
+        return list(self._cached_blocks)
 
     def base_blocks(self, *, item_partition_depth: int = 6) -> list[BaseBlock]:
         """

--- a/tests/docs/test_base_blocks.py
+++ b/tests/docs/test_base_blocks.py
@@ -339,3 +339,58 @@ def test_nested_list_spans_pairwise_non_overlapping():
     parent_text = text[bbs[0].block.span[0] : bbs[0].block.span[1]]
     assert "- nested" not in parent_text
     assert "item one" in parent_text
+
+
+def _covered_nonspace(text: str, bbs: list[BaseBlock]) -> set[int]:
+    """Indexes of non-whitespace source chars covered by some base-block span."""
+    covered: set[int] = set()
+    for bb in bbs:
+        s, e = bb.block.span
+        covered.update(range(s, e))
+    return {i for i in range(len(text)) if not text[i].isspace()} - covered
+
+
+def test_cover_invariant_trailing_content_after_sublist():
+    """A list item with content after a nested sublist must stay in the cover."""
+    text = dedent(
+        """
+        - item one text
+
+          - sub a
+          - sub b
+
+          trailing paragraph inside item one
+
+        - item two
+        """
+    ).strip()
+    bbs = base_blocks(text)
+    missing = _covered_nonspace(text, bbs)
+    assert not missing, (
+        f"uncovered non-whitespace at {sorted(missing)}: {''.join(text[i] for i in sorted(missing))!r}"
+    )
+
+
+def test_cover_invariant_content_between_two_sublists():
+    """Content between two sublists in one item must stay in the cover."""
+    text = dedent(
+        """
+        - item one
+
+          - sub a
+
+          middle text between sublists
+
+          - sub b
+
+        - item two
+        """
+    ).strip()
+    bbs = base_blocks(text)
+    missing = _covered_nonspace(text, bbs)
+    assert not missing, (
+        f"uncovered non-whitespace at {sorted(missing)}: {''.join(text[i] for i in sorted(missing))!r}"
+    )
+    # And spans remain ordered and non-overlapping.
+    for i in range(len(bbs) - 1):
+        assert bbs[i].block.span[1] <= bbs[i + 1].block.span[0]

--- a/tests/docs/test_base_blocks.py
+++ b/tests/docs/test_base_blocks.py
@@ -394,3 +394,76 @@ def test_cover_invariant_content_between_two_sublists():
     # And spans remain ordered and non-overlapping.
     for i in range(len(bbs) - 1):
         assert bbs[i].block.span[1] <= bbs[i + 1].block.span[0]
+
+
+def _assert_partition(text: str, bbs: list[BaseBlock]) -> None:
+    """Ordered, pairwise non-overlapping, every non-whitespace char covered exactly once."""
+    spans = [bb.block.span for bb in bbs]
+    assert spans == sorted(spans), "base blocks not in source order"
+    for i in range(len(spans) - 1):
+        assert spans[i][1] <= spans[i + 1][0], f"spans overlap at {i}: {spans[i]} / {spans[i + 1]}"
+    counts: dict[int, int] = {}
+    for s, e in spans:
+        for i in range(s, e):
+            counts[i] = counts.get(i, 0) + 1
+    for i, ch in enumerate(text):
+        if ch.isspace():
+            continue
+        assert counts.get(i, 0) == 1, f"char {i} ({ch!r}) covered {counts.get(i, 0)} times"
+
+
+def test_continuation_content_keeps_real_type_not_list_item():
+    """A list-item continuation paragraph after a sublist is typed `paragraph`, so it is
+    distinguishable from an independent top-level list item."""
+    text = dedent(
+        """
+        - item one text
+
+          - sub a
+          - sub b
+
+          trailing paragraph inside item one
+
+        - item two
+        """
+    ).strip()
+    bbs = base_blocks(text)
+    _assert_partition(text, bbs)
+
+    td = _types_and_depths(bbs)
+    # head(list_item,0), sub a(list_item,1), sub b(list_item,1),
+    # continuation(paragraph,0), item two(list_item,0)
+    assert td == [
+        (BlockType.list_item, 0),
+        (BlockType.list_item, 1),
+        (BlockType.list_item, 1),
+        (BlockType.paragraph, 0),
+        (BlockType.list_item, 0),
+    ]
+    continuation = next(bb for bb in bbs if bb.block.type == BlockType.paragraph)
+    assert (
+        "trailing paragraph inside item one"
+        in text[continuation.block.span[0] : continuation.block.span[1]]
+    )
+
+
+def test_partition_holds_for_content_between_two_sublists():
+    text = dedent(
+        """
+        - item one
+
+          - sub a
+
+          middle text between sublists
+
+          - sub b
+
+        - item two
+        """
+    ).strip()
+    bbs = base_blocks(text)
+    _assert_partition(text, bbs)
+    # The between-sublists content is a paragraph, not a list_item.
+    paras = [bb for bb in bbs if bb.block.type == BlockType.paragraph]
+    assert len(paras) == 1
+    assert "middle text between sublists" in text[paras[0].block.span[0] : paras[0].block.span[1]]

--- a/tests/docs/test_blocks.py
+++ b/tests/docs/test_blocks.py
@@ -298,10 +298,16 @@ def test_density_invariant_walk_blocks_tallies():
     assert dense_tally == loose_tally
 
 
-def test_blocks_is_cached_on_source():
-    """blocks() memoizes its parse so derived views share one parse."""
+def test_blocks_is_cached_but_returns_fresh_list():
+    """blocks() memoizes its parse (same Block objects) yet returns a fresh list each
+    call, so reordering/filtering the result cannot poison the shared cache."""
     td = TextDoc.from_text(_DOC)
-    assert td.blocks() is td.blocks()
+    first, second = td.blocks(), td.blocks()
+    assert first is not second
+    assert all(a is b for a, b in zip(first, second, strict=True))
+    # Mutating the returned list does not affect the next call.
+    first.clear()
+    assert len(td.blocks()) > 0
 
 
 def test_sections_reuse_doc_block_cache():

--- a/tests/docs/test_blocks.py
+++ b/tests/docs/test_blocks.py
@@ -296,3 +296,18 @@ def test_density_invariant_walk_blocks_tallies():
     dense_tally = tally(dense)
     loose_tally = tally(loose)
     assert dense_tally == loose_tally
+
+
+def test_blocks_is_cached_on_source():
+    """blocks() memoizes its parse so derived views share one parse."""
+    td = TextDoc.from_text(_DOC)
+    assert td.blocks() is td.blocks()
+
+
+def test_sections_reuse_doc_block_cache():
+    """A section's structural slice comes from the doc's cached parse, not a re-parse."""
+    td = TextDoc.from_text(_DOC)
+    doc_blocks = td.blocks()
+    for section in td.sections():
+        for block in section.blocks():
+            assert any(b.span == block.span for b in doc_blocks)

--- a/tests/docs/test_collect.py
+++ b/tests/docs/test_collect.py
@@ -248,3 +248,40 @@ def test_code_spans_inline():
     assert len(spans_no) == 0
     spans_yes = doc.collect(kinds={NodeKind.code_span}, recursive=True, inline=True)
     assert len(spans_yes) >= 1
+
+
+def test_collect_layer_filters_cross_layer_duplicates():
+    """A bare paragraph kind appears in both markdown and textual layers; `layer=`
+    selects one, eliminating cross-layer duplicate spans."""
+    td = TextDoc.from_text("A short paragraph.\n\nAnother paragraph.\n")
+
+    both = td.collect(kinds={NodeKind.paragraph}, recursive=True)
+    md_only = td.collect(kinds={NodeKind.paragraph}, recursive=True, layer={Layer.markdown})
+    txt_only = td.collect(kinds={NodeKind.paragraph}, recursive=True, layer={Layer.textual})
+
+    # Default (no layer) returns both layers; each single-layer query is a strict subset.
+    assert len(md_only) == 2
+    assert len(txt_only) == 2
+    assert len(both) == len(md_only) + len(txt_only)
+    assert {n.layer for n in md_only} == {Layer.markdown}
+    # Single-layer results have no duplicate spans.
+    md_spans = [n.source_span for n in md_only]
+    assert len(md_spans) == len(set(md_spans))
+
+
+def test_collect_layer_does_not_silently_drop_sections():
+    """The default (no `layer`) must still surface document-layer sections; restricting
+    to markdown is what hides them (the deliberate, explicit choice)."""
+    td = TextDoc.from_text("# Title\n\nBody paragraph.\n")
+    assert td.collect(kinds={NodeKind.section}, recursive=True)  # default: found
+    assert td.collect(kinds={NodeKind.section}, recursive=True, layer={Layer.markdown}) == []
+
+
+def test_textdoc_base_blocks_matches_free_function():
+    from chopdiff.docs.base_blocks import base_blocks as base_blocks_fn
+
+    text = "- one\n  - a\n  - b\n- two\n"
+    td = TextDoc.from_text(text)
+    method = td.base_blocks()
+    fn = base_blocks_fn(text)
+    assert [(b.block.span, b.depth) for b in method] == [(b.block.span, b.depth) for b in fn]

--- a/tests/golden/README.md
+++ b/tests/golden/README.md
@@ -1,0 +1,57 @@
+# Golden-Document Tests
+
+End-to-end “transparent box” tests for the document model.
+Each source document under `documents/` is converted by the model and serialized three
+ways; the serializations are committed under `expected/<doc>/` and compared on every
+run. One readable artifact per document shows every projection at once, so any change to
+any view appears in a diff.
+
+## Layout
+
+```
+documents/<doc>.md          source: Markdown with YAML frontmatter (name, description,
+                            optional item_partition_depth)
+expected/<doc>/report.yaml      multi-view report (base blocks + cover, sections/TOC,
+                                full node table, links by section, SpanRef round-trips)
+expected/<doc>/docgraph.yaml    the DocGraph projection as clean YAML
+expected/<doc>/reassembled.md   the editing view's reassembled (normalized) text
+```
+
+The serializer is the public, reusable `chopdiff.docs.debug` dumper (`doc_report`,
+`doc_graph_yaml`, `dump_views`) — usable on any document from a REPL or script, not just
+here.
+
+## Running and updating
+
+```bash
+uv run pytest tests/golden/test_golden_docs.py            # compare against goldens
+UPDATE_GOLDEN=1 uv run pytest tests/golden/test_golden_docs.py   # regenerate goldens
+git diff tests/golden/expected/                           # review the behavioral diff
+```
+
+After an intentional model change, regenerate, then **review the diff as a behavioral
+change**: if it is expected, commit the updated goldens; if not, it is a regression —
+fix the code.
+
+## Two layers of checking
+
+- `test_golden_artifacts` — raw diff against the committed serializations (catches any
+  unanticipated change anywhere in the output).
+- `test_model_invariants` — the model’s hard guarantees, enforced independently of the
+  golden diff so a semantic violation fails even if goldens are blindly regenerated:
+  base-block complete cover, SpanRef round-trips, unique node ids with valid
+  parent/child and DocGraph child references, span bounds, and `reassemble()`
+  idempotence.
+
+## Why no mocks or scrubbing
+
+The model is deterministic and hermetic — no clock, network, LLM, or randomness; node
+ids are a stable preorder counter, sha256 and token estimates are deterministic.
+So there is nothing to mock and no unstable field to scrub: output is byte-stable across
+runs.
+
+## Determinism note
+
+Node ids (`n0001…`) are deterministic and meaningful, so they appear verbatim in the
+goldens (not pattern-matched).
+Spans are Unicode code points, rendered `start:end`.

--- a/tests/golden/documents/footnotes_refs.md
+++ b/tests/golden/documents/footnotes_refs.md
@@ -1,0 +1,15 @@
+---
+name: footnotes_refs
+description: Reference-style links and footnotes, whose identities resolve across blocks
+  but whose rendered text has no contiguous source span (span=None handling).
+---
+# References
+
+See the [docs][d] and the [spec][s] for details.[^note]
+
+A bare autolink: <https://auto.example> and a plain https://bare.example URL.
+
+[d]: https://docs.example
+[s]: https://spec.example "Spec Title"
+
+[^note]: A footnote definition with its own text.

--- a/tests/golden/documents/inline_html.md
+++ b/tests/golden/documents/inline_html.md
@@ -1,0 +1,16 @@
+---
+name: inline_html
+description: Inline and block HTML mixed into Markdown (div/span), the precursor to the
+  synthetic layer; exercises html block typing and inline-html nodes.
+---
+# Inline HTML
+
+A paragraph with an <span class="hl">inline span</span> in the middle.
+
+<div class="callout">
+
+A div-wrapped paragraph of content.
+
+</div>
+
+Plain trailing paragraph.

--- a/tests/golden/documents/kitchen_sink.md
+++ b/tests/golden/documents/kitchen_sink.md
@@ -1,0 +1,29 @@
+---
+name: kitchen_sink
+description: Headings, nested and ordered lists, blockquote wrapping a table, inline and
+  image links, and a code span — broad coverage in one small document.
+---
+# Kitchen Sink
+
+Intro paragraph with an [inline link](https://a.example) and a `code span`.
+
+## Lists
+
+- top item with text
+  - nested one
+  - nested two
+
+  trailing text after the sublist
+
+1. ordered first
+2. ordered second
+
+## Quote
+
+> A blockquote wrapping a table:
+>
+> | a | b |
+> | - | - |
+> | 1 | 2 |
+
+![an image](https://img.example/x.png)

--- a/tests/golden/documents/malformed.md
+++ b/tests/golden/documents/malformed.md
@@ -1,0 +1,20 @@
+---
+name: malformed
+description: Malformed Markdown (unterminated code fence, ragged table, stray markers) to
+  confirm the model degrades to best-effort structure and never throws (P17).
+---
+# Malformed
+
+A paragraph then an unterminated fence:
+
+```python
+def f():
+    return 1
+
+## A heading that is actually inside the open fence?
+
+| ragged | table
+| - |
+| one | two | three |
+
+- item with [an unclosed link](http://x.example

--- a/tests/golden/documents/nested_list.md
+++ b/tests/golden/documents/nested_list.md
@@ -1,0 +1,17 @@
+---
+name: nested_list
+description: Deeply nested list with content after a sublist, partitioned at
+  item_partition_depth=2 so the cover invariant and the depth cap are both exercised.
+item_partition_depth: 2
+---
+# Nested List
+
+- level one item
+  - level two item
+    - level three item
+      - level four item
+
+    text between deep sublists at level two
+
+  more level-one content after the sublist
+- second top-level item

--- a/tests/golden/documents/tight_vs_loose.md
+++ b/tests/golden/documents/tight_vs_loose.md
@@ -1,0 +1,18 @@
+---
+name: tight_vs_loose
+description: The same list written tight (no blank lines) and loose (blank lines between
+  items); both must yield identical structure and tallies (density invariance).
+---
+# Tight
+
+- alpha
+- beta
+- gamma
+
+# Loose
+
+- alpha
+
+- beta
+
+- gamma

--- a/tests/golden/documents/unicode.md
+++ b/tests/golden/documents/unicode.md
@@ -1,0 +1,11 @@
+---
+name: unicode
+description: Emoji and multibyte characters, to confirm spans are Unicode code points and
+  round-trip exactly (not bytes or UTF-16 units).
+---
+# Unicode 🌍
+
+A paragraph with emoji 🚀 and accents café, naïve, Zürich, and a [liñk](https://û.example).
+
+- 日本語 item
+- emoji 🎉 item

--- a/tests/golden/expected/footnotes_refs/docgraph.yaml
+++ b/tests/golden/expected/footnotes_refs/docgraph.yaml
@@ -7,7 +7,6 @@ nodes:
 - id: n0001
   kind: heading
   layer: markdown
-  children: []
   source_span:
     start: 0
     end: 12
@@ -16,42 +15,36 @@ nodes:
 - id: n0002
   kind: paragraph
   layer: markdown
-  children: []
   source_span:
     start: 14
     end: 69
 - id: n0003
   kind: paragraph
   layer: markdown
-  children: []
   source_span:
     start: 71
     end: 148
 - id: n0004
   kind: paragraph
   layer: markdown
-  children: []
   source_span:
     start: 150
     end: 175
 - id: n0005
   kind: paragraph
   layer: markdown
-  children: []
   source_span:
     start: 176
     end: 214
 - id: n0006
   kind: footnote
   layer: markdown
-  children: []
   source_span:
     start: 216
     end: 265
 - id: n0007
   kind: section
   layer: document
-  children: []
   source_span:
     start: 0
     end: 265
@@ -68,8 +61,3 @@ views:
   - n0004
   - n0005
   - n0006
-  links: []
-  sentences: []
-annotations: []
-layout: []
-provenance: []

--- a/tests/golden/expected/footnotes_refs/docgraph.yaml
+++ b/tests/golden/expected/footnotes_refs/docgraph.yaml
@@ -1,0 +1,75 @@
+schema: DocGraph/v0.1
+source:
+  format: markdown
+  offset_unit: unicode_code_points
+  sha256: 1e66d85137792726196ad5ad436ad4e6119246562c670ad921359ccb48eabe10
+nodes:
+- id: n0001
+  kind: heading
+  layer: markdown
+  children: []
+  source_span:
+    start: 0
+    end: 12
+  attrs:
+    level: 1
+- id: n0002
+  kind: paragraph
+  layer: markdown
+  children: []
+  source_span:
+    start: 14
+    end: 69
+- id: n0003
+  kind: paragraph
+  layer: markdown
+  children: []
+  source_span:
+    start: 71
+    end: 148
+- id: n0004
+  kind: paragraph
+  layer: markdown
+  children: []
+  source_span:
+    start: 150
+    end: 175
+- id: n0005
+  kind: paragraph
+  layer: markdown
+  children: []
+  source_span:
+    start: 176
+    end: 214
+- id: n0006
+  kind: footnote
+  layer: markdown
+  children: []
+  source_span:
+    start: 216
+    end: 265
+- id: n0007
+  kind: section
+  layer: document
+  children: []
+  source_span:
+    start: 0
+    end: 265
+  attrs:
+    level: 1
+    title: References
+views:
+  toc:
+  - n0007
+  blocks:
+  - n0001
+  - n0002
+  - n0003
+  - n0004
+  - n0005
+  - n0006
+  links: []
+  sentences: []
+annotations: []
+layout: []
+provenance: []

--- a/tests/golden/expected/footnotes_refs/reassembled.md
+++ b/tests/golden/expected/footnotes_refs/reassembled.md
@@ -1,0 +1,9 @@
+# References
+
+See the [docs][d] and the [spec][s] for details.[^note]
+
+A bare autolink: <https://auto.example> and a plain https://bare.example URL.
+
+[d]: https://docs.example [s]: https://spec.example "Spec Title"
+
+[^note]: A footnote definition with its own text.

--- a/tests/golden/expected/footnotes_refs/report.yaml
+++ b/tests/golden/expected/footnotes_refs/report.yaml
@@ -1,0 +1,196 @@
+source:
+  sha256: 1e66d85137792726196ad5ad436ad4e6119246562c670ad921359ccb48eabe10
+  length: 266
+  size_summary: 265 bytes (10 lines, 5 paras, 5 sents, 32 words, ~70 tok)
+base_blocks:
+  cover_ok: true
+  uncovered_nonspace: 0
+  blocks:
+  - depth: 0
+    type: heading
+    span: 0:12
+    text: '# References'
+  - depth: 0
+    type: paragraph
+    span: 14:69
+    text: See the [docs][d] and the [spec][s] for details.[^note]
+  - depth: 0
+    type: paragraph
+    span: 71:148
+    text: 'A bare autolink: <https://auto.example> and a plain https://bare.example
+      URL.'
+  - depth: 0
+    type: paragraph
+    span: 150:175
+    text: '[d]: https://docs.example'
+  - depth: 0
+    type: paragraph
+    span: 176:214
+    text: '[s]: https://spec.example "Spec Title"'
+  - depth: 0
+    type: footnote
+    span: 216:265
+    text: '[^note]: A footnote definition with its own text.'
+sections:
+- level: 1
+  title: References
+  span: 0:265
+  words: 32
+node_table:
+- id: n0001
+  layer: markdown
+  kind: heading
+  span: 0:12
+  attrs:
+    level: 1
+- id: n0002
+  layer: markdown
+  kind: paragraph
+  span: 14:69
+- id: n0003
+  layer: markdown
+  kind: paragraph
+  span: 71:148
+- id: n0004
+  layer: markdown
+  kind: paragraph
+  span: 150:175
+- id: n0005
+  layer: markdown
+  kind: paragraph
+  span: 176:214
+- id: n0006
+  layer: markdown
+  kind: footnote
+  span: 216:265
+- id: n0007
+  layer: document
+  kind: section
+  span: 0:265
+  attrs:
+    level: 1
+    title: References
+- id: n0008
+  layer: textual
+  kind: paragraph
+  span: 0:12
+- id: n0009
+  layer: textual
+  kind: sentence
+  span: 0:12
+  parent: n0008
+  attrs:
+    text: '# References'
+- id: n0010
+  layer: textual
+  kind: paragraph
+  span: 14:69
+- id: n0011
+  layer: textual
+  kind: sentence
+  span: 14:69
+  parent: n0010
+  attrs:
+    text: See the [docs][d] and the [spec][s] for details.[^note]
+- id: n0012
+  layer: textual
+  kind: paragraph
+  span: 71:148
+- id: n0013
+  layer: textual
+  kind: sentence
+  span: 71:148
+  parent: n0012
+  attrs:
+    text: 'A bare autolink: <https://auto.example> and a plain https://bare.example
+      URL.'
+- id: n0014
+  layer: textual
+  kind: paragraph
+  span: 150:214
+- id: n0015
+  layer: textual
+  kind: sentence
+  span: 150:214
+  parent: n0014
+  attrs:
+    text: '[d]: https://docs.example [s]: https://spec.example "Spec Title"'
+- id: n0016
+  layer: textual
+  kind: paragraph
+  span: 216:265
+- id: n0017
+  layer: textual
+  kind: sentence
+  span: 216:265
+  parent: n0016
+  attrs:
+    text: '[^note]: A footnote definition with its own text.'
+- id: n0018
+  layer: markdown
+  kind: link
+  span: 22:31
+  parent: n0002
+  attrs:
+    url: https://docs.example
+    text: docs
+    section: n0007
+    sentence: n0011
+- id: n0019
+  layer: markdown
+  kind: link
+  span: 40:49
+  parent: n0002
+  attrs:
+    url: https://spec.example
+    text: spec
+    title: Spec Title
+    section: n0007
+    sentence: n0011
+- id: n0020
+  layer: markdown
+  kind: link
+  attrs:
+    url: https://auto.example
+    text: https://auto.example
+- id: n0021
+  layer: markdown
+  kind: link
+  attrs:
+    url: https://bare.example
+    text: https://bare.example
+- id: n0022
+  layer: markdown
+  kind: inline_html
+  span: 88:110
+  parent: n0003
+  attrs:
+    tag: <https://auto.example>
+    section: n0007
+    sentence: n0013
+links:
+- kind: link
+  text: docs
+  url: https://docs.example
+  span: 22:31
+  section: References
+- kind: link
+  text: spec
+  url: https://spec.example
+  span: 40:49
+  section: References
+- kind: link
+  text: https://auto.example
+  url: https://auto.example
+- kind: link
+  text: https://bare.example
+  url: https://bare.example
+spanrefs:
+- id: n0018
+  exact: '[docs][d]'
+  resolved: 22:31
+  ok: true
+- id: n0019
+  exact: '[spec][s]'
+  resolved: 40:49
+  ok: true

--- a/tests/golden/expected/inline_html/docgraph.yaml
+++ b/tests/golden/expected/inline_html/docgraph.yaml
@@ -7,7 +7,6 @@ nodes:
 - id: n0001
   kind: heading
   layer: markdown
-  children: []
   source_span:
     start: 0
     end: 13
@@ -16,42 +15,36 @@ nodes:
 - id: n0002
   kind: paragraph
   layer: markdown
-  children: []
   source_span:
     start: 15
     end: 85
 - id: n0003
   kind: paragraph
   layer: markdown
-  children: []
   source_span:
     start: 87
     end: 108
 - id: n0004
   kind: paragraph
   layer: markdown
-  children: []
   source_span:
     start: 110
     end: 145
 - id: n0005
   kind: paragraph
   layer: markdown
-  children: []
   source_span:
     start: 147
     end: 153
 - id: n0006
   kind: paragraph
   layer: markdown
-  children: []
   source_span:
     start: 155
     end: 180
 - id: n0007
   kind: section
   layer: document
-  children: []
   source_span:
     start: 0
     end: 180
@@ -68,8 +61,3 @@ views:
   - n0004
   - n0005
   - n0006
-  links: []
-  sentences: []
-annotations: []
-layout: []
-provenance: []

--- a/tests/golden/expected/inline_html/docgraph.yaml
+++ b/tests/golden/expected/inline_html/docgraph.yaml
@@ -1,0 +1,75 @@
+schema: DocGraph/v0.1
+source:
+  format: markdown
+  offset_unit: unicode_code_points
+  sha256: 535461f080b822c93de10f15dcf2b2593b62d5267ab6c87453640a5ea653c249
+nodes:
+- id: n0001
+  kind: heading
+  layer: markdown
+  children: []
+  source_span:
+    start: 0
+    end: 13
+  attrs:
+    level: 1
+- id: n0002
+  kind: paragraph
+  layer: markdown
+  children: []
+  source_span:
+    start: 15
+    end: 85
+- id: n0003
+  kind: paragraph
+  layer: markdown
+  children: []
+  source_span:
+    start: 87
+    end: 108
+- id: n0004
+  kind: paragraph
+  layer: markdown
+  children: []
+  source_span:
+    start: 110
+    end: 145
+- id: n0005
+  kind: paragraph
+  layer: markdown
+  children: []
+  source_span:
+    start: 147
+    end: 153
+- id: n0006
+  kind: paragraph
+  layer: markdown
+  children: []
+  source_span:
+    start: 155
+    end: 180
+- id: n0007
+  kind: section
+  layer: document
+  children: []
+  source_span:
+    start: 0
+    end: 180
+  attrs:
+    level: 1
+    title: Inline HTML
+views:
+  toc:
+  - n0007
+  blocks:
+  - n0001
+  - n0002
+  - n0003
+  - n0004
+  - n0005
+  - n0006
+  links: []
+  sentences: []
+annotations: []
+layout: []
+provenance: []

--- a/tests/golden/expected/inline_html/reassembled.md
+++ b/tests/golden/expected/inline_html/reassembled.md
@@ -1,0 +1,11 @@
+# Inline HTML
+
+A paragraph with an <span class="hl">inline span</span> in the middle.
+
+<div class="callout">
+
+A div-wrapped paragraph of content.
+
+</div>
+
+Plain trailing paragraph.

--- a/tests/golden/expected/inline_html/report.yaml
+++ b/tests/golden/expected/inline_html/report.yaml
@@ -171,5 +171,3 @@ node_table:
     tag: </div>
     section: n0007
     sentence: n0017
-links: []
-spanrefs: []

--- a/tests/golden/expected/inline_html/report.yaml
+++ b/tests/golden/expected/inline_html/report.yaml
@@ -1,0 +1,175 @@
+source:
+  sha256: 535461f080b822c93de10f15dcf2b2593b62d5267ab6c87453640a5ea653c249
+  length: 181
+  size_summary: 180 bytes (11 lines, 6 paras, 6 sents, 20 words, ~48 tok)
+base_blocks:
+  cover_ok: true
+  uncovered_nonspace: 0
+  blocks:
+  - depth: 0
+    type: heading
+    span: 0:13
+    text: '# Inline HTML'
+  - depth: 0
+    type: paragraph
+    span: 15:85
+    text: A paragraph with an <span class="hl">inline span</span> in the middle.
+  - depth: 0
+    type: paragraph
+    span: 87:108
+    text: <div class="callout">
+  - depth: 0
+    type: paragraph
+    span: 110:145
+    text: A div-wrapped paragraph of content.
+  - depth: 0
+    type: paragraph
+    span: 147:153
+    text: </div>
+  - depth: 0
+    type: paragraph
+    span: 155:180
+    text: Plain trailing paragraph.
+sections:
+- level: 1
+  title: Inline HTML
+  span: 0:180
+  words: 20
+node_table:
+- id: n0001
+  layer: markdown
+  kind: heading
+  span: 0:13
+  attrs:
+    level: 1
+- id: n0002
+  layer: markdown
+  kind: paragraph
+  span: 15:85
+- id: n0003
+  layer: markdown
+  kind: paragraph
+  span: 87:108
+- id: n0004
+  layer: markdown
+  kind: paragraph
+  span: 110:145
+- id: n0005
+  layer: markdown
+  kind: paragraph
+  span: 147:153
+- id: n0006
+  layer: markdown
+  kind: paragraph
+  span: 155:180
+- id: n0007
+  layer: document
+  kind: section
+  span: 0:180
+  attrs:
+    level: 1
+    title: Inline HTML
+- id: n0008
+  layer: textual
+  kind: paragraph
+  span: 0:13
+- id: n0009
+  layer: textual
+  kind: sentence
+  span: 0:13
+  parent: n0008
+  attrs:
+    text: '# Inline HTML'
+- id: n0010
+  layer: textual
+  kind: paragraph
+  span: 15:85
+- id: n0011
+  layer: textual
+  kind: sentence
+  span: 15:85
+  parent: n0010
+  attrs:
+    text: A paragraph with an <span class="hl">inline span</span> in the middle.
+- id: n0012
+  layer: textual
+  kind: paragraph
+  span: 87:108
+- id: n0013
+  layer: textual
+  kind: sentence
+  span: 87:108
+  parent: n0012
+  attrs:
+    text: <div class="callout">
+- id: n0014
+  layer: textual
+  kind: paragraph
+  span: 110:145
+- id: n0015
+  layer: textual
+  kind: sentence
+  span: 110:145
+  parent: n0014
+  attrs:
+    text: A div-wrapped paragraph of content.
+- id: n0016
+  layer: textual
+  kind: paragraph
+  span: 147:153
+- id: n0017
+  layer: textual
+  kind: sentence
+  span: 147:153
+  parent: n0016
+  attrs:
+    text: </div>
+- id: n0018
+  layer: textual
+  kind: paragraph
+  span: 155:180
+- id: n0019
+  layer: textual
+  kind: sentence
+  span: 155:180
+  parent: n0018
+  attrs:
+    text: Plain trailing paragraph.
+- id: n0020
+  layer: markdown
+  kind: inline_html
+  span: 35:52
+  parent: n0002
+  attrs:
+    tag: <span class="hl">
+    section: n0007
+    sentence: n0011
+- id: n0021
+  layer: markdown
+  kind: inline_html
+  span: 63:70
+  parent: n0002
+  attrs:
+    tag: </span>
+    section: n0007
+    sentence: n0011
+- id: n0022
+  layer: markdown
+  kind: inline_html
+  span: 87:108
+  parent: n0003
+  attrs:
+    tag: <div class="callout">
+    section: n0007
+    sentence: n0013
+- id: n0023
+  layer: markdown
+  kind: inline_html
+  span: 147:153
+  parent: n0005
+  attrs:
+    tag: </div>
+    section: n0007
+    sentence: n0017
+links: []
+spanrefs: []

--- a/tests/golden/expected/kitchen_sink/docgraph.yaml
+++ b/tests/golden/expected/kitchen_sink/docgraph.yaml
@@ -1,0 +1,270 @@
+schema: DocGraph/v0.1
+source:
+  format: markdown
+  offset_unit: unicode_code_points
+  sha256: 613b556081ab78fa2add904a0368d2d19cf6ca55170aaf0e40a466f6bee63d7f
+nodes:
+- id: n0001
+  kind: heading
+  layer: markdown
+  children: []
+  source_span:
+    start: 0
+    end: 14
+  attrs:
+    level: 1
+- id: n0002
+  kind: paragraph
+  layer: markdown
+  children: []
+  source_span:
+    start: 16
+    end: 91
+- id: n0003
+  kind: heading
+  layer: markdown
+  children: []
+  source_span:
+    start: 93
+    end: 101
+  attrs:
+    level: 2
+- id: n0004
+  kind: list
+  layer: markdown
+  children:
+  - n0005
+  source_span:
+    start: 103
+    end: 188
+  attrs:
+    tight: false
+    ordered: false
+- id: n0005
+  kind: list_item
+  layer: markdown
+  parent: n0004
+  children:
+  - n0006
+  - n0007
+  - n0012
+  source_span:
+    start: 103
+    end: 188
+- id: n0006
+  kind: paragraph
+  layer: markdown
+  parent: n0005
+  children: []
+  source_span:
+    start: 103
+    end: 123
+- id: n0007
+  kind: list
+  layer: markdown
+  parent: n0005
+  children:
+  - n0008
+  - n0010
+  source_span:
+    start: 126
+    end: 153
+  attrs:
+    tight: true
+    ordered: false
+- id: n0008
+  kind: list_item
+  layer: markdown
+  parent: n0007
+  children:
+  - n0009
+  source_span:
+    start: 126
+    end: 138
+- id: n0009
+  kind: paragraph
+  layer: markdown
+  parent: n0008
+  children: []
+  source_span:
+    start: 126
+    end: 138
+- id: n0010
+  kind: list_item
+  layer: markdown
+  parent: n0007
+  children:
+  - n0011
+  source_span:
+    start: 141
+    end: 153
+- id: n0011
+  kind: paragraph
+  layer: markdown
+  parent: n0010
+  children: []
+  source_span:
+    start: 141
+    end: 153
+- id: n0012
+  kind: paragraph
+  layer: markdown
+  parent: n0005
+  children: []
+  source_span:
+    start: 157
+    end: 188
+- id: n0013
+  kind: ordered_list
+  layer: markdown
+  children:
+  - n0014
+  - n0016
+  source_span:
+    start: 190
+    end: 224
+  attrs:
+    tight: true
+    ordered: true
+- id: n0014
+  kind: list_item
+  layer: markdown
+  parent: n0013
+  children:
+  - n0015
+  source_span:
+    start: 190
+    end: 206
+- id: n0015
+  kind: paragraph
+  layer: markdown
+  parent: n0014
+  children: []
+  source_span:
+    start: 190
+    end: 206
+- id: n0016
+  kind: list_item
+  layer: markdown
+  parent: n0013
+  children:
+  - n0017
+  source_span:
+    start: 207
+    end: 224
+- id: n0017
+  kind: paragraph
+  layer: markdown
+  parent: n0016
+  children: []
+  source_span:
+    start: 207
+    end: 224
+- id: n0018
+  kind: heading
+  layer: markdown
+  children: []
+  source_span:
+    start: 226
+    end: 234
+  attrs:
+    level: 2
+- id: n0019
+  kind: blockquote
+  layer: markdown
+  children:
+  - n0020
+  - n0021
+  source_span:
+    start: 236
+    end: 306
+- id: n0020
+  kind: paragraph
+  layer: markdown
+  parent: n0019
+  children: []
+  source_span:
+    start: 236
+    end: 268
+- id: n0021
+  kind: table
+  layer: markdown
+  parent: n0019
+  children: []
+  source_span:
+    start: 271
+    end: 306
+- id: n0022
+  kind: paragraph
+  layer: markdown
+  children: []
+  source_span:
+    start: 308
+    end: 346
+- id: n0023
+  kind: section
+  layer: document
+  children:
+  - n0024
+  - n0025
+  source_span:
+    start: 0
+    end: 346
+  attrs:
+    level: 1
+    title: Kitchen Sink
+- id: n0024
+  kind: section
+  layer: document
+  parent: n0023
+  children: []
+  source_span:
+    start: 93
+    end: 224
+  attrs:
+    level: 2
+    title: Lists
+- id: n0025
+  kind: section
+  layer: document
+  parent: n0023
+  children: []
+  source_span:
+    start: 226
+    end: 346
+  attrs:
+    level: 2
+    title: Quote
+views:
+  toc:
+  - n0023
+  - n0024
+  - n0025
+  blocks:
+  - n0001
+  - n0002
+  - n0003
+  - n0004
+  - n0005
+  - n0006
+  - n0007
+  - n0008
+  - n0009
+  - n0010
+  - n0011
+  - n0012
+  - n0013
+  - n0014
+  - n0015
+  - n0016
+  - n0017
+  - n0018
+  - n0019
+  - n0020
+  - n0021
+  - n0022
+  links: []
+  sentences: []
+annotations: []
+layout: []
+provenance: []

--- a/tests/golden/expected/kitchen_sink/docgraph.yaml
+++ b/tests/golden/expected/kitchen_sink/docgraph.yaml
@@ -7,7 +7,6 @@ nodes:
 - id: n0001
   kind: heading
   layer: markdown
-  children: []
   source_span:
     start: 0
     end: 14
@@ -16,14 +15,12 @@ nodes:
 - id: n0002
   kind: paragraph
   layer: markdown
-  children: []
   source_span:
     start: 16
     end: 91
 - id: n0003
   kind: heading
   layer: markdown
-  children: []
   source_span:
     start: 93
     end: 101
@@ -55,7 +52,6 @@ nodes:
   kind: paragraph
   layer: markdown
   parent: n0005
-  children: []
   source_span:
     start: 103
     end: 123
@@ -85,7 +81,6 @@ nodes:
   kind: paragraph
   layer: markdown
   parent: n0008
-  children: []
   source_span:
     start: 126
     end: 138
@@ -102,7 +97,6 @@ nodes:
   kind: paragraph
   layer: markdown
   parent: n0010
-  children: []
   source_span:
     start: 141
     end: 153
@@ -110,7 +104,6 @@ nodes:
   kind: paragraph
   layer: markdown
   parent: n0005
-  children: []
   source_span:
     start: 157
     end: 188
@@ -139,7 +132,6 @@ nodes:
   kind: paragraph
   layer: markdown
   parent: n0014
-  children: []
   source_span:
     start: 190
     end: 206
@@ -156,14 +148,12 @@ nodes:
   kind: paragraph
   layer: markdown
   parent: n0016
-  children: []
   source_span:
     start: 207
     end: 224
 - id: n0018
   kind: heading
   layer: markdown
-  children: []
   source_span:
     start: 226
     end: 234
@@ -182,7 +172,6 @@ nodes:
   kind: paragraph
   layer: markdown
   parent: n0019
-  children: []
   source_span:
     start: 236
     end: 268
@@ -190,14 +179,12 @@ nodes:
   kind: table
   layer: markdown
   parent: n0019
-  children: []
   source_span:
     start: 271
     end: 306
 - id: n0022
   kind: paragraph
   layer: markdown
-  children: []
   source_span:
     start: 308
     end: 346
@@ -217,7 +204,6 @@ nodes:
   kind: section
   layer: document
   parent: n0023
-  children: []
   source_span:
     start: 93
     end: 224
@@ -228,7 +214,6 @@ nodes:
   kind: section
   layer: document
   parent: n0023
-  children: []
   source_span:
     start: 226
     end: 346
@@ -263,8 +248,3 @@ views:
   - n0020
   - n0021
   - n0022
-  links: []
-  sentences: []
-annotations: []
-layout: []
-provenance: []

--- a/tests/golden/expected/kitchen_sink/reassembled.md
+++ b/tests/golden/expected/kitchen_sink/reassembled.md
@@ -1,0 +1,17 @@
+# Kitchen Sink
+
+Intro paragraph with an [inline link](https://a.example) and a `code span`.
+
+## Lists
+
+- top item with text - nested one - nested two
+
+trailing text after the sublist
+
+1. ordered first 2. ordered second
+
+## Quote
+
+> A blockquote wrapping a table: > > | a | b | > | - | - | > | 1 | 2 |
+
+![an image](https://img.example/x.png)

--- a/tests/golden/expected/kitchen_sink/report.yaml
+++ b/tests/golden/expected/kitchen_sink/report.yaml
@@ -1,0 +1,369 @@
+source:
+  sha256: 613b556081ab78fa2add904a0368d2d19cf6ca55170aaf0e40a466f6bee63d7f
+  length: 347
+  size_summary: 340 bytes (24 lines, 9 paras, 9 sents, 66 words, ~90 tok)
+base_blocks:
+  cover_ok: true
+  uncovered_nonspace: 0
+  blocks:
+  - depth: 0
+    type: heading
+    span: 0:14
+    text: '# Kitchen Sink'
+  - depth: 0
+    type: paragraph
+    span: 16:91
+    text: Intro paragraph with an [inline link](https://a.example) and a `code 
+      span`.
+  - depth: 0
+    type: heading
+    span: 93:101
+    text: '## Lists'
+  - depth: 0
+    type: list_item
+    span: 103:123
+    text: '- top item with text'
+  - depth: 1
+    type: list_item
+    span: 126:138
+    text: '- nested one'
+  - depth: 1
+    type: list_item
+    span: 141:153
+    text: '- nested two'
+  - depth: 0
+    type: list_item
+    span: 157:188
+    text: trailing text after the sublist
+  - depth: 0
+    type: list_item
+    span: 190:206
+    text: 1. ordered first
+  - depth: 0
+    type: list_item
+    span: 207:224
+    text: 2. ordered second
+  - depth: 0
+    type: heading
+    span: 226:234
+    text: '## Quote'
+  - depth: 0
+    type: blockquote
+    span: 236:306
+    text: |-
+      > A blockquote wrapping a table:
+      >
+      > | a | b |
+      > | - | - |
+      > | 1 | 2 |
+  - depth: 0
+    type: paragraph
+    span: 308:346
+    text: '![an image](https://img.example/x.png)'
+sections:
+- level: 1
+  title: Kitchen Sink
+  span: 0:346
+  words: 66
+- level: 2
+  title: Lists
+  span: 93:224
+  words: 24
+- level: 2
+  title: Quote
+  span: 226:346
+  words: 29
+node_table:
+- id: n0001
+  layer: markdown
+  kind: heading
+  span: 0:14
+  attrs:
+    level: 1
+- id: n0002
+  layer: markdown
+  kind: paragraph
+  span: 16:91
+- id: n0003
+  layer: markdown
+  kind: heading
+  span: 93:101
+  attrs:
+    level: 2
+- id: n0004
+  layer: markdown
+  kind: list
+  span: 103:188
+  attrs:
+    tight: false
+    ordered: false
+- id: n0005
+  layer: markdown
+  kind: list_item
+  span: 103:188
+  parent: n0004
+- id: n0006
+  layer: markdown
+  kind: paragraph
+  span: 103:123
+  parent: n0005
+- id: n0007
+  layer: markdown
+  kind: list
+  span: 126:153
+  parent: n0005
+  attrs:
+    tight: true
+    ordered: false
+- id: n0008
+  layer: markdown
+  kind: list_item
+  span: 126:138
+  parent: n0007
+- id: n0009
+  layer: markdown
+  kind: paragraph
+  span: 126:138
+  parent: n0008
+- id: n0010
+  layer: markdown
+  kind: list_item
+  span: 141:153
+  parent: n0007
+- id: n0011
+  layer: markdown
+  kind: paragraph
+  span: 141:153
+  parent: n0010
+- id: n0012
+  layer: markdown
+  kind: paragraph
+  span: 157:188
+  parent: n0005
+- id: n0013
+  layer: markdown
+  kind: ordered_list
+  span: 190:224
+  attrs:
+    tight: true
+    ordered: true
+- id: n0014
+  layer: markdown
+  kind: list_item
+  span: 190:206
+  parent: n0013
+- id: n0015
+  layer: markdown
+  kind: paragraph
+  span: 190:206
+  parent: n0014
+- id: n0016
+  layer: markdown
+  kind: list_item
+  span: 207:224
+  parent: n0013
+- id: n0017
+  layer: markdown
+  kind: paragraph
+  span: 207:224
+  parent: n0016
+- id: n0018
+  layer: markdown
+  kind: heading
+  span: 226:234
+  attrs:
+    level: 2
+- id: n0019
+  layer: markdown
+  kind: blockquote
+  span: 236:306
+- id: n0020
+  layer: markdown
+  kind: paragraph
+  span: 236:268
+  parent: n0019
+- id: n0021
+  layer: markdown
+  kind: table
+  span: 271:306
+  parent: n0019
+- id: n0022
+  layer: markdown
+  kind: paragraph
+  span: 308:346
+- id: n0023
+  layer: document
+  kind: section
+  span: 0:346
+  attrs:
+    level: 1
+    title: Kitchen Sink
+- id: n0024
+  layer: document
+  kind: section
+  span: 93:224
+  parent: n0023
+  attrs:
+    level: 2
+    title: Lists
+- id: n0025
+  layer: document
+  kind: section
+  span: 226:346
+  parent: n0023
+  attrs:
+    level: 2
+    title: Quote
+- id: n0026
+  layer: textual
+  kind: paragraph
+  span: 0:14
+- id: n0027
+  layer: textual
+  kind: sentence
+  span: 0:14
+  parent: n0026
+  attrs:
+    text: '# Kitchen Sink'
+- id: n0028
+  layer: textual
+  kind: paragraph
+  span: 16:91
+- id: n0029
+  layer: textual
+  kind: sentence
+  span: 16:91
+  parent: n0028
+  attrs:
+    text: Intro paragraph with an [inline link](https://a.example) and a `code 
+      span`.
+- id: n0030
+  layer: textual
+  kind: paragraph
+  span: 93:101
+- id: n0031
+  layer: textual
+  kind: sentence
+  span: 93:101
+  parent: n0030
+  attrs:
+    text: '## Lists'
+- id: n0032
+  layer: textual
+  kind: paragraph
+  span: 103:153
+- id: n0033
+  layer: textual
+  kind: sentence
+  span: 103:153
+  parent: n0032
+  attrs:
+    text: '- top item with text - nested one - nested two'
+- id: n0034
+  layer: textual
+  kind: paragraph
+  span: 157:188
+- id: n0035
+  layer: textual
+  kind: sentence
+  span: 157:188
+  parent: n0034
+  attrs:
+    text: trailing text after the sublist
+- id: n0036
+  layer: textual
+  kind: paragraph
+  span: 190:224
+- id: n0037
+  layer: textual
+  kind: sentence
+  span: 190:224
+  parent: n0036
+  attrs:
+    text: 1. ordered first 2. ordered second
+- id: n0038
+  layer: textual
+  kind: paragraph
+  span: 226:234
+- id: n0039
+  layer: textual
+  kind: sentence
+  span: 226:234
+  parent: n0038
+  attrs:
+    text: '## Quote'
+- id: n0040
+  layer: textual
+  kind: paragraph
+  span: 236:306
+- id: n0041
+  layer: textual
+  kind: sentence
+  span: 236:306
+  parent: n0040
+  attrs:
+    text: '> A blockquote wrapping a table: > > | a | b | > | - | - | > | 1 | 2 |'
+- id: n0042
+  layer: textual
+  kind: paragraph
+  span: 308:346
+- id: n0043
+  layer: textual
+  kind: sentence
+  span: 308:346
+  parent: n0042
+  attrs:
+    text: '![an image](https://img.example/x.png)'
+- id: n0044
+  layer: markdown
+  kind: link
+  span: 40:72
+  parent: n0002
+  attrs:
+    url: https://a.example
+    text: inline link
+    section: n0023
+    sentence: n0029
+- id: n0045
+  layer: markdown
+  kind: code_span
+  span: 79:90
+  parent: n0002
+  attrs:
+    content: code span
+    section: n0023
+    sentence: n0029
+- id: n0046
+  layer: markdown
+  kind: image
+  span: 308:346
+  parent: n0022
+  attrs:
+    url: https://img.example/x.png
+    text: an image
+    section: n0025
+    sentence: n0043
+links:
+- kind: link
+  text: inline link
+  url: https://a.example
+  span: 40:72
+  section: Kitchen Sink
+- kind: image
+  text: an image
+  url: https://img.example/x.png
+  span: 308:346
+  section: Quote
+spanrefs:
+- id: n0044
+  exact: '[inline link](https://a.example)'
+  resolved: 40:72
+  ok: true
+- id: n0045
+  exact: '`code span`'
+  resolved: 79:90
+  ok: true
+- id: n0046
+  exact: '![an image](https://img.example/x.png)'
+  resolved: 308:346
+  ok: true

--- a/tests/golden/expected/kitchen_sink/report.yaml
+++ b/tests/golden/expected/kitchen_sink/report.yaml
@@ -32,7 +32,7 @@ base_blocks:
     span: 141:153
     text: '- nested two'
   - depth: 0
-    type: list_item
+    type: paragraph
     span: 157:188
     text: trailing text after the sublist
   - depth: 0

--- a/tests/golden/expected/malformed/docgraph.yaml
+++ b/tests/golden/expected/malformed/docgraph.yaml
@@ -7,7 +7,6 @@ nodes:
 - id: n0001
   kind: heading
   layer: markdown
-  children: []
   source_span:
     start: 0
     end: 11
@@ -16,14 +15,12 @@ nodes:
 - id: n0002
   kind: paragraph
   layer: markdown
-  children: []
   source_span:
     start: 13
     end: 52
 - id: n0003
   kind: code
   layer: markdown
-  children: []
   source_span:
     start: 54
     end: 234
@@ -42,7 +39,6 @@ nodes:
   kind: section
   layer: document
   parent: n0004
-  children: []
   source_span:
     start: 87
     end: 234
@@ -57,8 +53,3 @@ views:
   - n0001
   - n0002
   - n0003
-  links: []
-  sentences: []
-annotations: []
-layout: []
-provenance: []

--- a/tests/golden/expected/malformed/docgraph.yaml
+++ b/tests/golden/expected/malformed/docgraph.yaml
@@ -1,0 +1,64 @@
+schema: DocGraph/v0.1
+source:
+  format: markdown
+  offset_unit: unicode_code_points
+  sha256: 717e85b9998d881966c78c9eec997fc3b0395d19cf4d2adfb9c0bddf2f916dc5
+nodes:
+- id: n0001
+  kind: heading
+  layer: markdown
+  children: []
+  source_span:
+    start: 0
+    end: 11
+  attrs:
+    level: 1
+- id: n0002
+  kind: paragraph
+  layer: markdown
+  children: []
+  source_span:
+    start: 13
+    end: 52
+- id: n0003
+  kind: code
+  layer: markdown
+  children: []
+  source_span:
+    start: 54
+    end: 234
+- id: n0004
+  kind: section
+  layer: document
+  children:
+  - n0005
+  source_span:
+    start: 0
+    end: 234
+  attrs:
+    level: 1
+    title: Malformed
+- id: n0005
+  kind: section
+  layer: document
+  parent: n0004
+  children: []
+  source_span:
+    start: 87
+    end: 234
+  attrs:
+    level: 2
+    title: A heading that is actually inside the open fence?
+views:
+  toc:
+  - n0004
+  - n0005
+  blocks:
+  - n0001
+  - n0002
+  - n0003
+  links: []
+  sentences: []
+annotations: []
+layout: []
+provenance: []

--- a/tests/golden/expected/malformed/reassembled.md
+++ b/tests/golden/expected/malformed/reassembled.md
@@ -1,0 +1,11 @@
+# Malformed
+
+A paragraph then an unterminated fence:
+
+```python def f(): return 1
+
+## A heading that is actually inside the open fence?
+
+| ragged | table | - | | one | two | three |
+
+- item with [an unclosed link](http://x.example

--- a/tests/golden/expected/malformed/report.yaml
+++ b/tests/golden/expected/malformed/report.yaml
@@ -134,5 +134,3 @@ node_table:
   parent: n0016
   attrs:
     text: '- item with [an unclosed link](http://x.example'
-links: []
-spanrefs: []

--- a/tests/golden/expected/malformed/report.yaml
+++ b/tests/golden/expected/malformed/report.yaml
@@ -1,0 +1,138 @@
+source:
+  sha256: 717e85b9998d881966c78c9eec997fc3b0395d19cf4d2adfb9c0bddf2f916dc5
+  length: 235
+  size_summary: 230 bytes (15 lines, 6 paras, 6 sents, 43 words, ~61 tok)
+base_blocks:
+  cover_ok: true
+  uncovered_nonspace: 0
+  blocks:
+  - depth: 0
+    type: heading
+    span: 0:11
+    text: '# Malformed'
+  - depth: 0
+    type: paragraph
+    span: 13:52
+    text: 'A paragraph then an unterminated fence:'
+  - depth: 0
+    type: code
+    span: 54:234
+    text: |-
+      ```python
+      def f():
+          return 1
+
+      ## A heading that is actually inside the open fence?
+
+      | ragged | table
+      | - |
+      | one | two | three |
+
+      - item with [an unclosed link](http://x.example
+sections:
+- level: 1
+  title: Malformed
+  span: 0:234
+  words: 43
+- level: 2
+  title: A heading that is actually inside the open fence?
+  span: 87:234
+  words: 30
+node_table:
+- id: n0001
+  layer: markdown
+  kind: heading
+  span: 0:11
+  attrs:
+    level: 1
+- id: n0002
+  layer: markdown
+  kind: paragraph
+  span: 13:52
+- id: n0003
+  layer: markdown
+  kind: code
+  span: 54:234
+- id: n0004
+  layer: document
+  kind: section
+  span: 0:234
+  attrs:
+    level: 1
+    title: Malformed
+- id: n0005
+  layer: document
+  kind: section
+  span: 87:234
+  parent: n0004
+  attrs:
+    level: 2
+    title: A heading that is actually inside the open fence?
+- id: n0006
+  layer: textual
+  kind: paragraph
+  span: 0:11
+- id: n0007
+  layer: textual
+  kind: sentence
+  span: 0:11
+  parent: n0006
+  attrs:
+    text: '# Malformed'
+- id: n0008
+  layer: textual
+  kind: paragraph
+  span: 13:52
+- id: n0009
+  layer: textual
+  kind: sentence
+  span: 13:52
+  parent: n0008
+  attrs:
+    text: 'A paragraph then an unterminated fence:'
+- id: n0010
+  layer: textual
+  kind: paragraph
+  span: 54:85
+- id: n0011
+  layer: textual
+  kind: sentence
+  span: 54:85
+  parent: n0010
+  attrs:
+    text: '```python def f(): return 1'
+- id: n0012
+  layer: textual
+  kind: paragraph
+  span: 87:139
+- id: n0013
+  layer: textual
+  kind: sentence
+  span: 87:139
+  parent: n0012
+  attrs:
+    text: '## A heading that is actually inside the open fence?'
+- id: n0014
+  layer: textual
+  kind: paragraph
+  span: 141:185
+- id: n0015
+  layer: textual
+  kind: sentence
+  span: 141:185
+  parent: n0014
+  attrs:
+    text: '| ragged | table | - | | one | two | three |'
+- id: n0016
+  layer: textual
+  kind: paragraph
+  span: 187:234
+- id: n0017
+  layer: textual
+  kind: sentence
+  span: 187:234
+  parent: n0016
+  attrs:
+    text: '- item with [an unclosed link](http://x.example'
+links: []
+spanrefs: []

--- a/tests/golden/expected/nested_list/docgraph.yaml
+++ b/tests/golden/expected/nested_list/docgraph.yaml
@@ -1,0 +1,205 @@
+schema: DocGraph/v0.1
+source:
+  format: markdown
+  offset_unit: unicode_code_points
+  sha256: 498ed9cd78568b06f4f871c8c9293ccdce03eab2e4b02fa8831ec43add094459
+nodes:
+- id: n0001
+  kind: heading
+  layer: markdown
+  children: []
+  source_span:
+    start: 0
+    end: 13
+  attrs:
+    level: 1
+- id: n0002
+  kind: list
+  layer: markdown
+  children:
+  - n0003
+  - n0016
+  source_span:
+    start: 15
+    end: 210
+  attrs:
+    tight: false
+    ordered: false
+- id: n0003
+  kind: list_item
+  layer: markdown
+  parent: n0002
+  children:
+  - n0004
+  - n0005
+  - n0015
+  source_span:
+    start: 15
+    end: 186
+- id: n0004
+  kind: paragraph
+  layer: markdown
+  parent: n0003
+  children: []
+  source_span:
+    start: 15
+    end: 31
+- id: n0005
+  kind: list
+  layer: markdown
+  parent: n0003
+  children:
+  - n0006
+  source_span:
+    start: 34
+    end: 142
+  attrs:
+    tight: false
+    ordered: false
+- id: n0006
+  kind: list_item
+  layer: markdown
+  parent: n0005
+  children:
+  - n0007
+  - n0008
+  - n0014
+  source_span:
+    start: 34
+    end: 142
+- id: n0007
+  kind: paragraph
+  layer: markdown
+  parent: n0006
+  children: []
+  source_span:
+    start: 34
+    end: 50
+- id: n0008
+  kind: list
+  layer: markdown
+  parent: n0006
+  children:
+  - n0009
+  source_span:
+    start: 55
+    end: 97
+  attrs:
+    tight: true
+    ordered: false
+- id: n0009
+  kind: list_item
+  layer: markdown
+  parent: n0008
+  children:
+  - n0010
+  - n0011
+  source_span:
+    start: 55
+    end: 97
+- id: n0010
+  kind: paragraph
+  layer: markdown
+  parent: n0009
+  children: []
+  source_span:
+    start: 55
+    end: 73
+- id: n0011
+  kind: list
+  layer: markdown
+  parent: n0009
+  children:
+  - n0012
+  source_span:
+    start: 80
+    end: 97
+  attrs:
+    tight: true
+    ordered: false
+- id: n0012
+  kind: list_item
+  layer: markdown
+  parent: n0011
+  children:
+  - n0013
+  source_span:
+    start: 80
+    end: 97
+- id: n0013
+  kind: paragraph
+  layer: markdown
+  parent: n0012
+  children: []
+  source_span:
+    start: 80
+    end: 97
+- id: n0014
+  kind: paragraph
+  layer: markdown
+  parent: n0006
+  children: []
+  source_span:
+    start: 103
+    end: 142
+- id: n0015
+  kind: paragraph
+  layer: markdown
+  parent: n0003
+  children: []
+  source_span:
+    start: 146
+    end: 186
+- id: n0016
+  kind: list_item
+  layer: markdown
+  parent: n0002
+  children:
+  - n0017
+  source_span:
+    start: 187
+    end: 210
+- id: n0017
+  kind: paragraph
+  layer: markdown
+  parent: n0016
+  children: []
+  source_span:
+    start: 187
+    end: 210
+- id: n0018
+  kind: section
+  layer: document
+  children: []
+  source_span:
+    start: 0
+    end: 210
+  attrs:
+    level: 1
+    title: Nested List
+views:
+  toc:
+  - n0018
+  blocks:
+  - n0001
+  - n0002
+  - n0003
+  - n0004
+  - n0005
+  - n0006
+  - n0007
+  - n0008
+  - n0009
+  - n0010
+  - n0011
+  - n0012
+  - n0013
+  - n0014
+  - n0015
+  - n0016
+  - n0017
+  links: []
+  sentences: []
+annotations: []
+layout: []
+provenance: []

--- a/tests/golden/expected/nested_list/docgraph.yaml
+++ b/tests/golden/expected/nested_list/docgraph.yaml
@@ -7,7 +7,6 @@ nodes:
 - id: n0001
   kind: heading
   layer: markdown
-  children: []
   source_span:
     start: 0
     end: 13
@@ -40,7 +39,6 @@ nodes:
   kind: paragraph
   layer: markdown
   parent: n0003
-  children: []
   source_span:
     start: 15
     end: 31
@@ -71,7 +69,6 @@ nodes:
   kind: paragraph
   layer: markdown
   parent: n0006
-  children: []
   source_span:
     start: 34
     end: 50
@@ -101,7 +98,6 @@ nodes:
   kind: paragraph
   layer: markdown
   parent: n0009
-  children: []
   source_span:
     start: 55
     end: 73
@@ -130,7 +126,6 @@ nodes:
   kind: paragraph
   layer: markdown
   parent: n0012
-  children: []
   source_span:
     start: 80
     end: 97
@@ -138,7 +133,6 @@ nodes:
   kind: paragraph
   layer: markdown
   parent: n0006
-  children: []
   source_span:
     start: 103
     end: 142
@@ -146,7 +140,6 @@ nodes:
   kind: paragraph
   layer: markdown
   parent: n0003
-  children: []
   source_span:
     start: 146
     end: 186
@@ -163,14 +156,12 @@ nodes:
   kind: paragraph
   layer: markdown
   parent: n0016
-  children: []
   source_span:
     start: 187
     end: 210
 - id: n0018
   kind: section
   layer: document
-  children: []
   source_span:
     start: 0
     end: 210
@@ -198,8 +189,3 @@ views:
   - n0015
   - n0016
   - n0017
-  links: []
-  sentences: []
-annotations: []
-layout: []
-provenance: []

--- a/tests/golden/expected/nested_list/reassembled.md
+++ b/tests/golden/expected/nested_list/reassembled.md
@@ -1,0 +1,7 @@
+# Nested List
+
+- level one item - level two item - level three item - level four item
+
+text between deep sublists at level two
+
+more level-one content after the sublist - second top-level item

--- a/tests/golden/expected/nested_list/report.yaml
+++ b/tests/golden/expected/nested_list/report.yaml
@@ -1,0 +1,189 @@
+source:
+  sha256: 498ed9cd78568b06f4f871c8c9293ccdce03eab2e4b02fa8831ec43add094459
+  length: 211
+  size_summary: 192 bytes (11 lines, 4 paras, 4 sents, 36 words, ~51 tok)
+base_blocks:
+  cover_ok: true
+  uncovered_nonspace: 0
+  blocks:
+  - depth: 0
+    type: heading
+    span: 0:13
+    text: '# Nested List'
+  - depth: 0
+    type: list_item
+    span: 15:31
+    text: '- level one item'
+  - depth: 1
+    type: list_item
+    span: 34:142
+    text: |-
+      - level two item
+          - level three item
+            - level four item
+
+          text between deep sublists at level two
+  - depth: 0
+    type: list_item
+    span: 146:186
+    text: more level-one content after the sublist
+  - depth: 0
+    type: list_item
+    span: 187:210
+    text: '- second top-level item'
+sections:
+- level: 1
+  title: Nested List
+  span: 0:210
+  words: 36
+node_table:
+- id: n0001
+  layer: markdown
+  kind: heading
+  span: 0:13
+  attrs:
+    level: 1
+- id: n0002
+  layer: markdown
+  kind: list
+  span: 15:210
+  attrs:
+    tight: false
+    ordered: false
+- id: n0003
+  layer: markdown
+  kind: list_item
+  span: 15:186
+  parent: n0002
+- id: n0004
+  layer: markdown
+  kind: paragraph
+  span: 15:31
+  parent: n0003
+- id: n0005
+  layer: markdown
+  kind: list
+  span: 34:142
+  parent: n0003
+  attrs:
+    tight: false
+    ordered: false
+- id: n0006
+  layer: markdown
+  kind: list_item
+  span: 34:142
+  parent: n0005
+- id: n0007
+  layer: markdown
+  kind: paragraph
+  span: 34:50
+  parent: n0006
+- id: n0008
+  layer: markdown
+  kind: list
+  span: 55:97
+  parent: n0006
+  attrs:
+    tight: true
+    ordered: false
+- id: n0009
+  layer: markdown
+  kind: list_item
+  span: 55:97
+  parent: n0008
+- id: n0010
+  layer: markdown
+  kind: paragraph
+  span: 55:73
+  parent: n0009
+- id: n0011
+  layer: markdown
+  kind: list
+  span: 80:97
+  parent: n0009
+  attrs:
+    tight: true
+    ordered: false
+- id: n0012
+  layer: markdown
+  kind: list_item
+  span: 80:97
+  parent: n0011
+- id: n0013
+  layer: markdown
+  kind: paragraph
+  span: 80:97
+  parent: n0012
+- id: n0014
+  layer: markdown
+  kind: paragraph
+  span: 103:142
+  parent: n0006
+- id: n0015
+  layer: markdown
+  kind: paragraph
+  span: 146:186
+  parent: n0003
+- id: n0016
+  layer: markdown
+  kind: list_item
+  span: 187:210
+  parent: n0002
+- id: n0017
+  layer: markdown
+  kind: paragraph
+  span: 187:210
+  parent: n0016
+- id: n0018
+  layer: document
+  kind: section
+  span: 0:210
+  attrs:
+    level: 1
+    title: Nested List
+- id: n0019
+  layer: textual
+  kind: paragraph
+  span: 0:13
+- id: n0020
+  layer: textual
+  kind: sentence
+  span: 0:13
+  parent: n0019
+  attrs:
+    text: '# Nested List'
+- id: n0021
+  layer: textual
+  kind: paragraph
+  span: 15:97
+- id: n0022
+  layer: textual
+  kind: sentence
+  span: 15:97
+  parent: n0021
+  attrs:
+    text: '- level one item - level two item - level three item - level four item'
+- id: n0023
+  layer: textual
+  kind: paragraph
+  span: 103:142
+- id: n0024
+  layer: textual
+  kind: sentence
+  span: 103:142
+  parent: n0023
+  attrs:
+    text: text between deep sublists at level two
+- id: n0025
+  layer: textual
+  kind: paragraph
+  span: 146:210
+- id: n0026
+  layer: textual
+  kind: sentence
+  span: 146:210
+  parent: n0025
+  attrs:
+    text: more level-one content after the sublist - second top-level item
+links: []
+spanrefs: []

--- a/tests/golden/expected/nested_list/report.yaml
+++ b/tests/golden/expected/nested_list/report.yaml
@@ -24,7 +24,7 @@ base_blocks:
 
           text between deep sublists at level two
   - depth: 0
-    type: list_item
+    type: paragraph
     span: 146:186
     text: more level-one content after the sublist
   - depth: 0
@@ -185,5 +185,3 @@ node_table:
   parent: n0025
   attrs:
     text: more level-one content after the sublist - second top-level item
-links: []
-spanrefs: []

--- a/tests/golden/expected/tight_vs_loose/docgraph.yaml
+++ b/tests/golden/expected/tight_vs_loose/docgraph.yaml
@@ -7,7 +7,6 @@ nodes:
 - id: n0001
   kind: heading
   layer: markdown
-  children: []
   source_span:
     start: 0
     end: 7
@@ -39,7 +38,6 @@ nodes:
   kind: paragraph
   layer: markdown
   parent: n0003
-  children: []
   source_span:
     start: 9
     end: 16
@@ -56,7 +54,6 @@ nodes:
   kind: paragraph
   layer: markdown
   parent: n0005
-  children: []
   source_span:
     start: 17
     end: 23
@@ -73,14 +70,12 @@ nodes:
   kind: paragraph
   layer: markdown
   parent: n0007
-  children: []
   source_span:
     start: 24
     end: 31
 - id: n0009
   kind: heading
   layer: markdown
-  children: []
   source_span:
     start: 33
     end: 40
@@ -112,7 +107,6 @@ nodes:
   kind: paragraph
   layer: markdown
   parent: n0011
-  children: []
   source_span:
     start: 42
     end: 49
@@ -129,7 +123,6 @@ nodes:
   kind: paragraph
   layer: markdown
   parent: n0013
-  children: []
   source_span:
     start: 51
     end: 57
@@ -146,14 +139,12 @@ nodes:
   kind: paragraph
   layer: markdown
   parent: n0015
-  children: []
   source_span:
     start: 59
     end: 66
 - id: n0017
   kind: section
   layer: document
-  children: []
   source_span:
     start: 0
     end: 31
@@ -163,7 +154,6 @@ nodes:
 - id: n0018
   kind: section
   layer: document
-  children: []
   source_span:
     start: 33
     end: 66
@@ -191,8 +181,3 @@ views:
   - n0014
   - n0015
   - n0016
-  links: []
-  sentences: []
-annotations: []
-layout: []
-provenance: []

--- a/tests/golden/expected/tight_vs_loose/docgraph.yaml
+++ b/tests/golden/expected/tight_vs_loose/docgraph.yaml
@@ -1,0 +1,198 @@
+schema: DocGraph/v0.1
+source:
+  format: markdown
+  offset_unit: unicode_code_points
+  sha256: 12543093d867364bae9479159f1c005534e1e6a68c74918ea1dab4a0527455f5
+nodes:
+- id: n0001
+  kind: heading
+  layer: markdown
+  children: []
+  source_span:
+    start: 0
+    end: 7
+  attrs:
+    level: 1
+- id: n0002
+  kind: list
+  layer: markdown
+  children:
+  - n0003
+  - n0005
+  - n0007
+  source_span:
+    start: 9
+    end: 31
+  attrs:
+    tight: true
+    ordered: false
+- id: n0003
+  kind: list_item
+  layer: markdown
+  parent: n0002
+  children:
+  - n0004
+  source_span:
+    start: 9
+    end: 16
+- id: n0004
+  kind: paragraph
+  layer: markdown
+  parent: n0003
+  children: []
+  source_span:
+    start: 9
+    end: 16
+- id: n0005
+  kind: list_item
+  layer: markdown
+  parent: n0002
+  children:
+  - n0006
+  source_span:
+    start: 17
+    end: 23
+- id: n0006
+  kind: paragraph
+  layer: markdown
+  parent: n0005
+  children: []
+  source_span:
+    start: 17
+    end: 23
+- id: n0007
+  kind: list_item
+  layer: markdown
+  parent: n0002
+  children:
+  - n0008
+  source_span:
+    start: 24
+    end: 31
+- id: n0008
+  kind: paragraph
+  layer: markdown
+  parent: n0007
+  children: []
+  source_span:
+    start: 24
+    end: 31
+- id: n0009
+  kind: heading
+  layer: markdown
+  children: []
+  source_span:
+    start: 33
+    end: 40
+  attrs:
+    level: 1
+- id: n0010
+  kind: list
+  layer: markdown
+  children:
+  - n0011
+  - n0013
+  - n0015
+  source_span:
+    start: 42
+    end: 66
+  attrs:
+    tight: false
+    ordered: false
+- id: n0011
+  kind: list_item
+  layer: markdown
+  parent: n0010
+  children:
+  - n0012
+  source_span:
+    start: 42
+    end: 49
+- id: n0012
+  kind: paragraph
+  layer: markdown
+  parent: n0011
+  children: []
+  source_span:
+    start: 42
+    end: 49
+- id: n0013
+  kind: list_item
+  layer: markdown
+  parent: n0010
+  children:
+  - n0014
+  source_span:
+    start: 51
+    end: 57
+- id: n0014
+  kind: paragraph
+  layer: markdown
+  parent: n0013
+  children: []
+  source_span:
+    start: 51
+    end: 57
+- id: n0015
+  kind: list_item
+  layer: markdown
+  parent: n0010
+  children:
+  - n0016
+  source_span:
+    start: 59
+    end: 66
+- id: n0016
+  kind: paragraph
+  layer: markdown
+  parent: n0015
+  children: []
+  source_span:
+    start: 59
+    end: 66
+- id: n0017
+  kind: section
+  layer: document
+  children: []
+  source_span:
+    start: 0
+    end: 31
+  attrs:
+    level: 1
+    title: Tight
+- id: n0018
+  kind: section
+  layer: document
+  children: []
+  source_span:
+    start: 33
+    end: 66
+  attrs:
+    level: 1
+    title: Loose
+views:
+  toc:
+  - n0017
+  - n0018
+  blocks:
+  - n0001
+  - n0002
+  - n0003
+  - n0004
+  - n0005
+  - n0006
+  - n0007
+  - n0008
+  - n0009
+  - n0010
+  - n0011
+  - n0012
+  - n0013
+  - n0014
+  - n0015
+  - n0016
+  links: []
+  sentences: []
+annotations: []
+layout: []
+provenance: []

--- a/tests/golden/expected/tight_vs_loose/reassembled.md
+++ b/tests/golden/expected/tight_vs_loose/reassembled.md
@@ -1,0 +1,11 @@
+# Tight
+
+- alpha - beta - gamma
+
+# Loose
+
+- alpha
+
+- beta
+
+- gamma

--- a/tests/golden/expected/tight_vs_loose/report.yaml
+++ b/tests/golden/expected/tight_vs_loose/report.yaml
@@ -1,0 +1,218 @@
+source:
+  sha256: 12543093d867364bae9479159f1c005534e1e6a68c74918ea1dab4a0527455f5
+  length: 67
+  size_summary: 66 bytes (13 lines, 6 paras, 6 sents, 16 words, ~18 tok)
+base_blocks:
+  cover_ok: true
+  uncovered_nonspace: 0
+  blocks:
+  - depth: 0
+    type: heading
+    span: 0:7
+    text: '# Tight'
+  - depth: 0
+    type: list_item
+    span: 9:16
+    text: '- alpha'
+  - depth: 0
+    type: list_item
+    span: 17:23
+    text: '- beta'
+  - depth: 0
+    type: list_item
+    span: 24:31
+    text: '- gamma'
+  - depth: 0
+    type: heading
+    span: 33:40
+    text: '# Loose'
+  - depth: 0
+    type: list_item
+    span: 42:49
+    text: '- alpha'
+  - depth: 0
+    type: list_item
+    span: 51:57
+    text: '- beta'
+  - depth: 0
+    type: list_item
+    span: 59:66
+    text: '- gamma'
+sections:
+- level: 1
+  title: Tight
+  span: 0:31
+  words: 8
+- level: 1
+  title: Loose
+  span: 33:66
+  words: 8
+node_table:
+- id: n0001
+  layer: markdown
+  kind: heading
+  span: 0:7
+  attrs:
+    level: 1
+- id: n0002
+  layer: markdown
+  kind: list
+  span: 9:31
+  attrs:
+    tight: true
+    ordered: false
+- id: n0003
+  layer: markdown
+  kind: list_item
+  span: 9:16
+  parent: n0002
+- id: n0004
+  layer: markdown
+  kind: paragraph
+  span: 9:16
+  parent: n0003
+- id: n0005
+  layer: markdown
+  kind: list_item
+  span: 17:23
+  parent: n0002
+- id: n0006
+  layer: markdown
+  kind: paragraph
+  span: 17:23
+  parent: n0005
+- id: n0007
+  layer: markdown
+  kind: list_item
+  span: 24:31
+  parent: n0002
+- id: n0008
+  layer: markdown
+  kind: paragraph
+  span: 24:31
+  parent: n0007
+- id: n0009
+  layer: markdown
+  kind: heading
+  span: 33:40
+  attrs:
+    level: 1
+- id: n0010
+  layer: markdown
+  kind: list
+  span: 42:66
+  attrs:
+    tight: false
+    ordered: false
+- id: n0011
+  layer: markdown
+  kind: list_item
+  span: 42:49
+  parent: n0010
+- id: n0012
+  layer: markdown
+  kind: paragraph
+  span: 42:49
+  parent: n0011
+- id: n0013
+  layer: markdown
+  kind: list_item
+  span: 51:57
+  parent: n0010
+- id: n0014
+  layer: markdown
+  kind: paragraph
+  span: 51:57
+  parent: n0013
+- id: n0015
+  layer: markdown
+  kind: list_item
+  span: 59:66
+  parent: n0010
+- id: n0016
+  layer: markdown
+  kind: paragraph
+  span: 59:66
+  parent: n0015
+- id: n0017
+  layer: document
+  kind: section
+  span: 0:31
+  attrs:
+    level: 1
+    title: Tight
+- id: n0018
+  layer: document
+  kind: section
+  span: 33:66
+  attrs:
+    level: 1
+    title: Loose
+- id: n0019
+  layer: textual
+  kind: paragraph
+  span: 0:7
+- id: n0020
+  layer: textual
+  kind: sentence
+  span: 0:7
+  parent: n0019
+  attrs:
+    text: '# Tight'
+- id: n0021
+  layer: textual
+  kind: paragraph
+  span: 9:31
+- id: n0022
+  layer: textual
+  kind: sentence
+  span: 9:31
+  parent: n0021
+  attrs:
+    text: '- alpha - beta - gamma'
+- id: n0023
+  layer: textual
+  kind: paragraph
+  span: 33:40
+- id: n0024
+  layer: textual
+  kind: sentence
+  span: 33:40
+  parent: n0023
+  attrs:
+    text: '# Loose'
+- id: n0025
+  layer: textual
+  kind: paragraph
+  span: 42:49
+- id: n0026
+  layer: textual
+  kind: sentence
+  span: 42:49
+  parent: n0025
+  attrs:
+    text: '- alpha'
+- id: n0027
+  layer: textual
+  kind: paragraph
+  span: 51:57
+- id: n0028
+  layer: textual
+  kind: sentence
+  span: 51:57
+  parent: n0027
+  attrs:
+    text: '- beta'
+- id: n0029
+  layer: textual
+  kind: paragraph
+  span: 59:66
+- id: n0030
+  layer: textual
+  kind: sentence
+  span: 59:66
+  parent: n0029
+  attrs:
+    text: '- gamma'
+links: []
+spanrefs: []

--- a/tests/golden/expected/tight_vs_loose/report.yaml
+++ b/tests/golden/expected/tight_vs_loose/report.yaml
@@ -214,5 +214,3 @@ node_table:
   parent: n0029
   attrs:
     text: '- gamma'
-links: []
-spanrefs: []

--- a/tests/golden/expected/unicode/docgraph.yaml
+++ b/tests/golden/expected/unicode/docgraph.yaml
@@ -7,7 +7,6 @@ nodes:
 - id: n0001
   kind: heading
   layer: markdown
-  children: []
   source_span:
     start: 0
     end: 11
@@ -16,7 +15,6 @@ nodes:
 - id: n0002
   kind: paragraph
   layer: markdown
-  children: []
   source_span:
     start: 13
     end: 103
@@ -45,7 +43,6 @@ nodes:
   kind: paragraph
   layer: markdown
   parent: n0004
-  children: []
   source_span:
     start: 105
     end: 115
@@ -62,14 +59,12 @@ nodes:
   kind: paragraph
   layer: markdown
   parent: n0006
-  children: []
   source_span:
     start: 116
     end: 130
 - id: n0008
   kind: section
   layer: document
-  children: []
   source_span:
     start: 0
     end: 130
@@ -87,8 +82,3 @@ views:
   - n0005
   - n0006
   - n0007
-  links: []
-  sentences: []
-annotations: []
-layout: []
-provenance: []

--- a/tests/golden/expected/unicode/docgraph.yaml
+++ b/tests/golden/expected/unicode/docgraph.yaml
@@ -1,0 +1,94 @@
+schema: DocGraph/v0.1
+source:
+  format: markdown
+  offset_unit: unicode_code_points
+  sha256: b70e09493e94a9a4bd182afa3d2b701cab1358e4cb2f6da058db3e342814ce82
+nodes:
+- id: n0001
+  kind: heading
+  layer: markdown
+  children: []
+  source_span:
+    start: 0
+    end: 11
+  attrs:
+    level: 1
+- id: n0002
+  kind: paragraph
+  layer: markdown
+  children: []
+  source_span:
+    start: 13
+    end: 103
+- id: n0003
+  kind: list
+  layer: markdown
+  children:
+  - n0004
+  - n0006
+  source_span:
+    start: 105
+    end: 130
+  attrs:
+    tight: true
+    ordered: false
+- id: n0004
+  kind: list_item
+  layer: markdown
+  parent: n0003
+  children:
+  - n0005
+  source_span:
+    start: 105
+    end: 115
+- id: n0005
+  kind: paragraph
+  layer: markdown
+  parent: n0004
+  children: []
+  source_span:
+    start: 105
+    end: 115
+- id: n0006
+  kind: list_item
+  layer: markdown
+  parent: n0003
+  children:
+  - n0007
+  source_span:
+    start: 116
+    end: 130
+- id: n0007
+  kind: paragraph
+  layer: markdown
+  parent: n0006
+  children: []
+  source_span:
+    start: 116
+    end: 130
+- id: n0008
+  kind: section
+  layer: document
+  children: []
+  source_span:
+    start: 0
+    end: 130
+  attrs:
+    level: 1
+    title: Unicode 🌍
+views:
+  toc:
+  - n0008
+  blocks:
+  - n0001
+  - n0002
+  - n0003
+  - n0004
+  - n0005
+  - n0006
+  - n0007
+  links: []
+  sentences: []
+annotations: []
+layout: []
+provenance: []

--- a/tests/golden/expected/unicode/reassembled.md
+++ b/tests/golden/expected/unicode/reassembled.md
@@ -1,0 +1,5 @@
+# Unicode 🌍
+
+A paragraph with emoji 🚀 and accents café, naïve, Zürich, and a [liñk](https://û.example).
+
+- 日本語 item - emoji 🎉 item

--- a/tests/golden/expected/unicode/report.yaml
+++ b/tests/golden/expected/unicode/report.yaml
@@ -1,0 +1,130 @@
+source:
+  sha256: b70e09493e94a9a4bd182afa3d2b701cab1358e4cb2f6da058db3e342814ce82
+  length: 131
+  size_summary: 150 bytes (6 lines, 3 paras, 3 sents, 23 words, ~35 tok)
+base_blocks:
+  cover_ok: true
+  uncovered_nonspace: 0
+  blocks:
+  - depth: 0
+    type: heading
+    span: 0:11
+    text: '# Unicode 🌍'
+  - depth: 0
+    type: paragraph
+    span: 13:103
+    text: A paragraph with emoji 🚀 and accents café, naïve, Zürich, and a 
+      [liñk](https://û.example).
+  - depth: 0
+    type: list_item
+    span: 105:115
+    text: '- 日本語 item'
+  - depth: 0
+    type: list_item
+    span: 116:130
+    text: '- emoji 🎉 item'
+sections:
+- level: 1
+  title: Unicode 🌍
+  span: 0:130
+  words: 23
+node_table:
+- id: n0001
+  layer: markdown
+  kind: heading
+  span: 0:11
+  attrs:
+    level: 1
+- id: n0002
+  layer: markdown
+  kind: paragraph
+  span: 13:103
+- id: n0003
+  layer: markdown
+  kind: list
+  span: 105:130
+  attrs:
+    tight: true
+    ordered: false
+- id: n0004
+  layer: markdown
+  kind: list_item
+  span: 105:115
+  parent: n0003
+- id: n0005
+  layer: markdown
+  kind: paragraph
+  span: 105:115
+  parent: n0004
+- id: n0006
+  layer: markdown
+  kind: list_item
+  span: 116:130
+  parent: n0003
+- id: n0007
+  layer: markdown
+  kind: paragraph
+  span: 116:130
+  parent: n0006
+- id: n0008
+  layer: document
+  kind: section
+  span: 0:130
+  attrs:
+    level: 1
+    title: Unicode 🌍
+- id: n0009
+  layer: textual
+  kind: paragraph
+  span: 0:11
+- id: n0010
+  layer: textual
+  kind: sentence
+  span: 0:11
+  parent: n0009
+  attrs:
+    text: '# Unicode 🌍'
+- id: n0011
+  layer: textual
+  kind: paragraph
+  span: 13:103
+- id: n0012
+  layer: textual
+  kind: sentence
+  span: 13:103
+  parent: n0011
+  attrs:
+    text: A paragraph with emoji 🚀 and accents café, naïve, Zürich, and a 
+      [liñk](https://û.example).
+- id: n0013
+  layer: textual
+  kind: paragraph
+  span: 105:130
+- id: n0014
+  layer: textual
+  kind: sentence
+  span: 105:130
+  parent: n0013
+  attrs:
+    text: '- 日本語 item - emoji 🎉 item'
+- id: n0015
+  layer: markdown
+  kind: link
+  span: 77:102
+  parent: n0002
+  attrs:
+    url: https://û.example
+    text: liñk
+    section: n0008
+    sentence: n0012
+links:
+- kind: link
+  text: liñk
+  url: https://û.example
+  span: 77:102
+  section: Unicode 🌍
+spanrefs:
+- id: n0015
+  exact: '[liñk](https://û.example)'
+  resolved: 77:102
+  ok: true

--- a/tests/golden/test_golden_docs.py
+++ b/tests/golden/test_golden_docs.py
@@ -24,6 +24,7 @@ from pathlib import Path
 
 from frontmatter_format import fmf_read
 
+from chopdiff.docs.base_blocks import base_blocks
 from chopdiff.docs.debug import doc_graph_yaml, doc_report, doc_report_data
 from chopdiff.docs.text_doc import TextDoc
 
@@ -106,11 +107,22 @@ def test_model_invariants():
         data = doc_report_data(td, item_partition_depth=depth)
         where = path.stem
 
-        # Base-block partition is a complete cover of all non-whitespace source (P13).
-        assert data["base_blocks"]["cover_ok"], (
-            f"{where}: base_blocks left {data['base_blocks']['uncovered_nonspace']} "
-            "non-whitespace chars uncovered"
-        )
+        # Base-block partition: ordered, pairwise non-overlapping, and covering every
+        # non-whitespace character exactly once (P13) — the documented contract, not just
+        # "some block touches each char".
+        spans = [b.block.span for b in base_blocks(source, item_partition_depth=depth)]
+        assert spans == sorted(spans), f"{where}: base blocks not in source order"
+        for i in range(len(spans) - 1):
+            assert spans[i][1] <= spans[i + 1][0], f"{where}: base-block spans overlap at {i}"
+        cover: dict[int, int] = {}
+        for s, e in spans:
+            for i in range(s, e):
+                cover[i] = cover.get(i, 0) + 1
+        for i, ch in enumerate(source):
+            if not ch.isspace():
+                assert cover.get(i, 0) == 1, (
+                    f"{where}: char {i} ({ch!r}) covered {cover.get(i, 0)}x"
+                )
 
         # Every located inline node round-trips through SpanRef (P6/SpanRef).
         for row in data["spanrefs"]:

--- a/tests/golden/test_golden_docs.py
+++ b/tests/golden/test_golden_docs.py
@@ -1,0 +1,144 @@
+"""
+Golden-document tests: each source document under `documents/` is converted by the model
+and serialized three ways (`report.yaml`, `docgraph.yaml`, `reassembled.md`); the
+serializations are committed under `expected/<doc>/` and compared on every run.
+
+This is transparent-box testing — one readable artifact per document shows every
+projection at once, so any change to any view appears in a diff. Alongside the raw diff,
+`test_model_invariants` enforces the model's hard guarantees programmatically, so a
+semantic violation fails even if the goldens are regenerated without review.
+
+Source documents are Markdown with YAML frontmatter (`name`, `description`, optional
+`item_partition_depth`). Regenerate goldens after an intentional change with:
+
+    UPDATE_GOLDEN=1 uv run pytest tests/golden/test_golden_docs.py
+
+then review `git diff tests/golden/expected/`.
+"""
+
+from __future__ import annotations
+
+import difflib
+import os
+from pathlib import Path
+
+from frontmatter_format import fmf_read
+
+from chopdiff.docs.debug import doc_graph_yaml, doc_report, doc_report_data
+from chopdiff.docs.text_doc import TextDoc
+
+_HERE = Path(__file__).parent
+_DOCS_DIR = _HERE / "documents"
+_EXPECTED_DIR = _HERE / "expected"
+_UPDATE = bool(os.environ.get("UPDATE_GOLDEN"))
+
+
+def _docs() -> list[Path]:
+    return sorted(_DOCS_DIR.glob("*.md"))
+
+
+def _load(path: Path) -> tuple[str, int]:
+    """Return the document body and its `item_partition_depth` option (default 6)."""
+    content, meta = fmf_read(path)
+    depth = 6
+    if meta and "item_partition_depth" in meta:
+        depth = int(meta["item_partition_depth"])  # pyright: ignore[reportArgumentType]
+    return content, depth
+
+
+def _artifacts(content: str, depth: int) -> dict[str, str]:
+    td = TextDoc.from_text(content)
+    return {
+        "report.yaml": doc_report(td, item_partition_depth=depth),
+        "docgraph.yaml": doc_graph_yaml(td),
+        "reassembled.md": td.reassemble(),
+    }
+
+
+def test_golden_artifacts():
+    docs = _docs()
+    assert docs, f"no corpus documents found in {_DOCS_DIR}"
+
+    failures: list[str] = []
+    for path in docs:
+        content, depth = _load(path)
+        artifacts = _artifacts(content, depth)
+        dest = _EXPECTED_DIR / path.stem
+
+        if _UPDATE:
+            dest.mkdir(parents=True, exist_ok=True)
+            for name, text in artifacts.items():
+                (dest / name).write_text(text, encoding="utf-8")
+            continue
+
+        for name, actual in artifacts.items():
+            golden_path = dest / name
+            if not golden_path.exists():
+                failures.append(f"{path.stem}/{name}: missing golden (run UPDATE_GOLDEN=1)")
+                continue
+            expected = golden_path.read_text(encoding="utf-8")
+            if actual != expected:
+                diff = "".join(
+                    difflib.unified_diff(
+                        expected.splitlines(keepends=True),
+                        actual.splitlines(keepends=True),
+                        fromfile=f"golden/{name}",
+                        tofile=f"actual/{name}",
+                    )
+                )
+                failures.append(f"{path.stem}/{name} differs:\n{diff}")
+
+    if _UPDATE:
+        return
+    if failures:
+        raise AssertionError("\n\n".join(failures))
+
+
+def test_model_invariants():
+    """The model's hard guarantees, checked independently of the golden diff."""
+    docs = _docs()
+    assert docs, f"no corpus documents found in {_DOCS_DIR}"
+
+    for path in docs:
+        content, depth = _load(path)
+        td = TextDoc.from_text(content)
+        source = td.source_text or td.reassemble()
+        data = doc_report_data(td, item_partition_depth=depth)
+        where = path.stem
+
+        # Base-block partition is a complete cover of all non-whitespace source (P13).
+        assert data["base_blocks"]["cover_ok"], (
+            f"{where}: base_blocks left {data['base_blocks']['uncovered_nonspace']} "
+            "non-whitespace chars uncovered"
+        )
+
+        # Every located inline node round-trips through SpanRef (P6/SpanRef).
+        for row in data["spanrefs"]:
+            assert row["ok"], f"{where}: SpanRef did not round-trip for {row['id']}"
+
+        table = td.node_table()
+        # Node ids unique and every parent/child reference resolves.
+        assert len(table.nodes) == len({n.id for n in table.nodes.values()})
+        for nid, n in table.nodes.items():
+            if n.parent is not None:
+                assert n.parent in table.nodes, f"{where}: dangling parent {n.parent} on {nid}"
+            for cid in n.children:
+                assert cid in table.nodes, f"{where}: dangling child {cid} on {nid}"
+            # Source-backed block/section nodes are span-exact and whitespace-trimmed (P6).
+            if n.source_span is not None:
+                s, e = n.source_span
+                assert 0 <= s <= e <= len(source)
+
+        # DocGraph child references are all valid within the projection.
+        ids = {nm.id for nm in td.graph().nodes}
+        for nm in td.graph().nodes:
+            for cid in nm.children:
+                assert cid in ids, f"{where}: docgraph child {cid} missing for {nm.id}"
+
+        # Normalized-form idempotence (P11): `reassemble()` produces the editing view's
+        # normalized text (which may differ from the source for constructs the editing
+        # view normalizes, e.g. multi-line reference definitions). Re-parsing and
+        # re-reassembling that normalized text must be a fixed point.
+        normalized = td.reassemble()
+        renormalized = TextDoc.from_text(normalized).reassemble()
+        assert normalized == renormalized, f"{where}: reassemble() is not idempotent"

--- a/uv.lock
+++ b/uv.lock
@@ -6,9 +6,9 @@ requires-python = ">=3.11, <4.0"
 exclude-newer = "2026-05-11T00:00:00Z"
 
 [options.exclude-newer-package]
-idna = "2026-05-13T00:00:00Z"
-flowmark = "2026-05-30T00:00:00Z"
 strif = "2026-05-24T00:00:00Z"
+flowmark = "2026-05-30T00:00:00Z"
+idna = "2026-05-13T00:00:00Z"
 
 [[package]]
 name = "annotated-types"
@@ -162,6 +162,7 @@ source = { editable = "." }
 dependencies = [
     { name = "cydifflib" },
     { name = "flowmark" },
+    { name = "frontmatter-format" },
     { name = "funlog" },
     { name = "marko" },
     { name = "prettyfmt" },
@@ -194,6 +195,7 @@ dev = [
 requires-dist = [
     { name = "cydifflib", specifier = ">=1.2.0" },
     { name = "flowmark", specifier = ">=0.7.1" },
+    { name = "frontmatter-format", specifier = ">=0.3.0" },
     { name = "funlog", specifier = ">=0.2.1" },
     { name = "marko", specifier = ">=2.2.2" },
     { name = "prettyfmt", specifier = ">=0.3.0" },
@@ -342,6 +344,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cd/30/747d36d6636550b7c325d760e2a3744b668aedd53901bad31027cf838161/flowmark-0.7.1.tar.gz", hash = "sha256:ddd64c71e49533b9a02b235d18464acb6d9c8f35e1e229e40b72814c375d894f", size = 549045, upload-time = "2026-05-29T03:35:19.625Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/bd/78167bec4f04d1825c523c01b4e9ee442ca9bb63b0cc3aa3780fd39f8b4d/flowmark-0.7.1-py3-none-any.whl", hash = "sha256:6566a358cb29fa89f1ea791e50c5f6fa3f317af60f09c7ec0a7f8110fc3974d6", size = 83675, upload-time = "2026-05-29T03:35:20.744Z" },
+]
+
+[[package]]
+name = "frontmatter-format"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ruamel-yaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/eb850cd4d32cafc342dbb3a8b64058511da188c7270a61219788ac141ca6/frontmatter_format-0.3.0.tar.gz", hash = "sha256:4ebd3d3068315945d418dfd320ce6ed727b90e1605473c6244039d34cbcb0253", size = 439709, upload-time = "2026-02-28T22:37:37.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/67/b003f8d851679714e00cc5353dd772027529d893b346f91279d0b9f17f17/frontmatter_format-0.3.0-py3-none-any.whl", hash = "sha256:55c1dafbcb0ca5dee5ff3e1dcb6c3fbde6d18860a2250c9d67779fd91c86c81e", size = 13824, upload-time = "2026-02-28T22:37:35.821Z" },
 ]
 
 [[package]]
@@ -921,6 +935,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Two stacked efforts on the post-PR-#12 document model: (1) grounding the design in an
explicit principle set and fixing the drift/defects a review surfaced, and (2) a
deterministic, transparent-box golden-document test layer plus the reusable
`chopdiff.docs.debug` dumper that powers it. All changes are additive or
behavior-preserving except one defect fix (`base_blocks()` cover).

## Changes

**Doc-model refinements**
- `docs/textdoc-spec.md`: explicit three-tier **Principles (P1–P18)** under a retitled
  §2 "Principles and Goals" (section numbers unchanged so code's "section 6/10/12" refs
  stay valid), a "Pitfalls and Key Decisions" note, and goals annotated with the
  principles they realize. §3/§13 corrected: the **source + offset space is the canonical
  substrate**; the node table is one projection.
- **Fix (`base_blocks()` cover):** content following/between a nested sublist inside a
  list item was dropped from the partition; it is now a complete cover again.
- **Perf:** memoized `TextDoc.blocks()` / `links()`; `Section.blocks()`/`links()` slice
  the shared cached parse instead of re-parsing per section (a TOC walk was quadratic);
  `build_node_table()` reuses `doc.blocks()`.
- **`collect(layer=)`** on the free function and `TextDoc.collect()` (default = all
  layers) so callers can scope away cross-layer duplicates; deterministic sort for
  `None`-span nodes; removed a dead image branch in `_build_inline_nodes`.
- **`TextDoc.base_blocks()`** method wrapping the free function.

**Golden-document testing + debug dumper**
- **`chopdiff.docs.debug`** (public): `doc_report`, `doc_graph_yaml`, `dump_views` — clean
  deterministic standard-format views of any document.
- **`DocGraph.to_yaml()`** — clean block-style YAML alongside the JSON.
- **`tests/golden/`**: 7 Markdown+frontmatter source docs and 21 committed YAML/MD golden
  artifacts. `test_golden_artifacts` diffs the serializations; `test_model_invariants`
  enforces cover, SpanRef round-trips, id/ref validity, span bounds, and `reassemble()`
  idempotence independently of the diff. `UPDATE_GOLDEN=1` regenerates; README documents
  the workflow.
- **New runtime dep:** `frontmatter-format>=0.3.0` (first-party; brings `ruamel-yaml`),
  added under the existing 14-day cool-off — resolved `frontmatter-format 0.3.0` /
  `ruamel-yaml 0.19.1`, both pre-cutoff, no exception needed. Lockfile committed.

## Test Plan

### Validation already performed (on this branch)
- [x] **Full suite green:** `make test` → **284 passed** (was 275 on main; +9 unit, +2
  golden, +ongoing). 0 failures.
- [x] **Lint/type-check clean:** `make lint` (ruff + basedpyright) → 0 errors, 0 warnings.
- [x] **`base_blocks()` cover fix is test-first:** added cover-invariant tests
  (trailing-content-after-sublist, content-between-two-sublists) that **fail on the old
  code and pass on the new**; verified the dropped content is recovered.
- [x] **Memoization verified:** `blocks() is blocks()` is now `True`; a section's
  structural slice is drawn from the doc's cached parse.
- [x] **`collect(layer=)` verified:** a `paragraph` query returns one node per requested
  layer (no cross-layer duplicates); default-all still surfaces document-layer sections
  (no silent drop).
- [x] **Golden invariants hold across all 7 corpus docs**, including `malformed.md` (no
  throw; complete cover) and `unicode.md` (code-point spans round-trip).
- [x] **Dumper determinism:** same input → byte-identical YAML on repeat.
- [x] **Supply chain:** `uv sync --locked` passes (frozen); dep resolved within the
  cool-off; lockfile reviewed (only `frontmatter-format` + `ruamel-yaml` added; the
  C-extension `ruamel.yaml.clib` is not pulled; both are pure-Python wheels, no sdist
  build).
- [x] **Golden update workflow:** `UPDATE_GOLDEN=1 uv run pytest` regenerates artifacts;
  re-run with goldens committed passes clean.

### Reviewer validation steps
- [ ] `make` (sync + lint + test) is green on a clean checkout.
- [ ] Skim `docs/textdoc-spec.md` §2 Principles and the §13 pitfalls note for wording.
- [ ] Review the golden artifacts as behavioral specs — in particular
      `tests/golden/expected/{tight_vs_loose,footnotes_refs,malformed}/report.yaml`
      (density invariance, reference-link `span=None`, robustness).
- [ ] Confirm the `frontmatter-format` runtime dependency is acceptable for the core lib
      (it is first-party; alternative was a `[debug]` extra — see the plan's resolved
      decision).

### Follow-ups intentionally not in this PR (tracked)
- `chopdiff-iw09` (P3 bug): autolinks and bare URLs get `span=None` in `_block_links`
  (no section attribution) — pre-existing, surfaced by the golden corpus.
- Not yet exercised by goldens (candidate corpus additions): nested **blockquotes**,
  multi-paragraph **list items** with code blocks, **setext** headings, **HTML block**
  vs inline-HTML edge cases, and `detail={text,inline}` / non-default `include` DocGraph
  variants.
- `DocGraph` YAML is a second serialization, not a frozen contract — no cross-language
  schema check yet.

## Related Beads

Doc-model refinements (closed): `chopdiff-3725`, `chopdiff-sphn`, `chopdiff-gsy2`,
`chopdiff-nyx0`, `chopdiff-e2gc`, `chopdiff-s23g`, `chopdiff-eps0`, `chopdiff-5l0h`.
Golden testing (closed): epic `chopdiff-m3dm` + `chopdiff-in9t`, `chopdiff-q32e`,
`chopdiff-16qy`, `chopdiff-9ouo`, `chopdiff-37wh`, `chopdiff-nawo`.
Open follow-up: `chopdiff-iw09`.

Specs: `plan-2026-05-31-doc-model-refinements.md`, `plan-2026-05-31-golden-doc-testing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
