### PR TITLE
Doc model v0.3.1 review: Tier A correctness + Tier B interval/sections + parse-once perf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,13 @@ with layers, the `base_blocks()` sequential partition, `collect()` query primiti
   block scope, superseding `block_type_counts()` convenience accessors.
   The `layer=` filter scopes a query to one or more parse layers (default: all layers),
   since the same span can appear as nodes in several layers.
+  Two relation families select candidates: the tree relation `subtree_of=` (a node's
+  within-layer subtree) and the cross-layer interval relations `within=` /`overlaps=`
+  (each takes a node id or a span), so `within=section_id` gathers everything inside a
+  section without `recursive=True`. (`scope=`/`contains=` remain as deprecated aliases.)
 - **`SpanRef` span-reference type.** Quote-canonical, offset-hinted span references for
-  durable annotation anchoring (exact fast path within a parse, fuzzy re-anchor across
-  edits).
+  durable annotation anchoring (exact-quote resolution with prefix/suffix
+  disambiguation; fuzzy re-anchoring deferred).
 - **`DocGraph` Pydantic projection.** `TextDoc.graph(include=, detail=)` builds a
   serialized, language-neutral JSON contract (schema “DocGraph/v0.1”) with composable
   `Layer` and `Detail` axes.
@@ -53,6 +57,15 @@ with layers, the `base_blocks()` sequential partition, `collect()` query primiti
 - **Structural-parse memoization.** `TextDoc.blocks()` is now cached on the immutable
   `source_text`, and `Section.blocks()` / `Section.links()` slice that single cached
   parse instead of re-parsing the whole document per section (a TOC walk was quadratic).
+- **Sections built from structural headings.** `sections()`/`toc()` now derive headings
+  from the structural parse (top-level `heading` blocks) instead of the blank-line
+  paragraph view, so a `#`-prefixed line isolated from inside a fenced code block is no
+  longer mistaken for a section heading. Behavior change: such phantom sections no longer
+  appear (e.g. the `malformed` golden loses one).
+- **Linear node-table assembly.** Inline-element attribution (containing block, section,
+  and sentence) now goes through a per-layer `IntervalIndex` instead of scanning the
+  whole table per inline element, so `build_node_table` is linear rather than
+  `O(inline × nodes)` on link-heavy or large documents.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,13 @@ with layers, the `base_blocks()` sequential partition, `collect()` query primiti
   and sentence) now goes through a per-layer `IntervalIndex` instead of scanning the
   whole table per inline element, so `build_node_table` is linear rather than
   `O(inline × nodes)` on link-heavy or large documents.
+- **Single shared parse with thread-safe caching.** `blocks()`, `links()`, and
+  `base_blocks()` now derive from one cached marko parse of `source_text` instead of each
+  re-parsing the whole document, roughly halving `node_table()` build time (one full
+  parse instead of two). Document-level derivations are memoized under a per-instance
+  reentrant lock, so concurrent reads compute each cache at most once and observe the
+  same value; reads are otherwise side-effect-free and deterministic. See the `TextDoc`
+  read-time-caching contract.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,8 +89,9 @@ with layers, the `base_blocks()` sequential partition, `collect()` query primiti
 
 Makes `TextDoc` block-aware end to end: an exact-span structural block tree, a section
 hierarchy with rolled-up stats, inline-link rollups, and link-aware sentence spans.
-The structural view is the canonical normalized form, with every other view (sections,
-block-type slices, tallies) derived from it: no stored counts.
+The source text and its offset space are canonical; every view (the structural block
+tree, sections, block-type slices, tallies) is a projection over that substrate: no
+stored counts.
 Block boundaries and spans now come straight from flowmark’s parser, so chopdiff carries
 no Markdown block-detection regex of its own.
 

--- a/docs/textdoc-spec.md
+++ b/docs/textdoc-spec.md
@@ -400,26 +400,30 @@ All calculated over the node table; nothing stores counts.
 The surface is **one general query primitive, no blessed per-kind rollups** (DR-4):
 
 ```python
-collect(scope=None, *, kinds=None, where=None, recursive=False, inline=False,
-        contains=None, layer=None) -> list[Node]
+collect(*, subtree_of=None, within=None, overlaps=None,
+        kinds=None, where=None, recursive=False, inline=False, layer=None) -> list[Node]
 ```
 
 Available as `doc.collect(...)` (and as the free `collect(table, ...)` over a node
-table). `scope=` restricts to a node id's subtree (within-layer parent/children);
-`contains=(start, end)` restricts to nodes whose span falls inside that offset range —
-the cross-layer mechanism, e.g. pass a section's `span` to gather what is inside it.
+table). Two distinct relations select candidates. The **tree** relation `subtree_of=`
+takes a node id and restricts to that node's within-layer parent/child subtree
+(`recursive` descends it). The **interval** relations are cross-layer and offset-based,
+each accepting a node id or `(start, end)` span: `within=` keeps nodes whose span is
+contained in the region (e.g. `within=section_id` for everything inside a section);
+`overlaps=` keeps nodes whose span merely intersects the region. Supplying an interval
+relation scans the whole document, so `within=section_id` needs no `recursive=True`.
 `kinds=` selects by node kind (the typed common case); `where=` is a `Node -> bool`
-predicate escape hatch; `recursive` descends into children; `inline` includes inline
-nodes (an explicit inline `kinds` such as `{NodeKind.link}` implies this); `layer=`
-restricts to parse layers. It returns **nodes** (each with `span`, `attrs`, edges).
-**Counts, values, and groupings are standard Python** over the result, documented with
-worked examples, not separate methods:
+predicate escape hatch; `inline` includes inline nodes (an explicit inline `kinds` such
+as `{NodeKind.link}` implies this); `layer=` restricts to parse layers. It returns
+**nodes** (each with `span`, `attrs`, edges). (`scope=` and `contains=` remain as
+deprecated aliases for `subtree_of=` and `within=`.) **Counts, values, and groupings are
+standard Python** over the result, documented with worked examples, not separate methods:
 
 ```python
 doc.collect(kinds={NodeKind.table}, recursive=True)        # the tables (values + spans)
 len(doc.collect(kinds={NodeKind.table}, recursive=True))   # how many
 Counter(n.kind for n in doc.collect(recursive=True))       # tally by kind
-doc.collect(contains=section.span, kinds={NodeKind.link}, recursive=True)  # links in a section
+doc.collect(within=section_id, kinds={NodeKind.link})      # links in a section
 ```
 
 Slice-by-block-type, per-section rollups, and element rollups are all expressions of

--- a/docs/textdoc-spec.md
+++ b/docs/textdoc-spec.md
@@ -400,21 +400,26 @@ All calculated over the node table; nothing stores counts.
 The surface is **one general query primitive, no blessed per-kind rollups** (DR-4):
 
 ```python
-collect(*, kinds=None, where=None, recursive=False, inline=False) -> list[Node]
+collect(scope=None, *, kinds=None, where=None, recursive=False, inline=False,
+        contains=None, layer=None) -> list[Node]
 ```
 
-at document / section / block scope (`dg`, `dg.section(id)`, `dg.node(id)`). `kinds=`
-selects by node kind (the typed common case); `where=` is a `Node -> bool` predicate
-escape hatch; `recursive` descends into children; `inline` includes inline nodes.
-It returns **nodes** (each with `span`, `attrs`, edges).
+Available as `doc.collect(...)` (and as the free `collect(table, ...)` over a node
+table). `scope=` restricts to a node id's subtree (within-layer parent/children);
+`contains=(start, end)` restricts to nodes whose span falls inside that offset range —
+the cross-layer mechanism, e.g. pass a section's `span` to gather what is inside it.
+`kinds=` selects by node kind (the typed common case); `where=` is a `Node -> bool`
+predicate escape hatch; `recursive` descends into children; `inline` includes inline
+nodes (an explicit inline `kinds` such as `{NodeKind.link}` implies this); `layer=`
+restricts to parse layers. It returns **nodes** (each with `span`, `attrs`, edges).
 **Counts, values, and groupings are standard Python** over the result, documented with
 worked examples, not separate methods:
 
 ```python
-dg.collect(kinds={NodeKind.table}, recursive=True)        # the tables (values + spans)
-len(dg.collect(kinds={NodeKind.table}, recursive=True))   # how many
-Counter(n.kind for n in dg.collect(recursive=True))       # tally by kind
-dg.section(s3).collect(kinds={NodeKind.link}, recursive=True)   # links in section 3
+doc.collect(kinds={NodeKind.table}, recursive=True)        # the tables (values + spans)
+len(doc.collect(kinds={NodeKind.table}, recursive=True))   # how many
+Counter(n.kind for n in doc.collect(recursive=True))       # tally by kind
+doc.collect(contains=section.span, kinds={NodeKind.link}, recursive=True)  # links in a section
 ```
 
 Slice-by-block-type, per-section rollups, and element rollups are all expressions of
@@ -594,9 +599,10 @@ Non-obvious choices, each grounded in a principle:
   children, including blockquote and list-item block children); `base_blocks()`
   sequential partition with its non-overlapping cover invariant; the single `collect()`
   primitive (superseding `block_type_counts()`; migration:
-  `Counter(n.kind for n in doc.graph().collect(...))`); composable `include` layers and
-  `detail` payload options; the `DocGraph` Pydantic schema ("DocGraph/v0.1"); and the
-  `SpanRef` contract with exact resolution (fuzzy re-anchor wired behind it).
+  `Counter(n.kind for n in doc.collect(recursive=True))`); composable `include` layers
+  and `detail` payload options; the `DocGraph` Pydantic schema ("DocGraph/v0.1"); and the
+  `SpanRef` contract with exact + prefix/suffix quote resolution (fuzzy re-anchoring
+  deferred).
 - **In progress:** annotation layer, synthetic layer (re-expressing `TextNode` tag
   chunking as a layer), cross-layer structural edits, and operation/provenance/layout
   layers. Tracked by epic `chopdiff-8q8q`; sequenced in

--- a/docs/textdoc-spec.md
+++ b/docs/textdoc-spec.md
@@ -396,7 +396,10 @@ block↔inline relationships are node edges, and “links in section 3” is a s
 
 ## 9. Derived Views and Rollups
 
-All calculated over the node table; nothing stores counts.
+All derived from the canonical source/offset substrate (the node table is the
+id-addressed projection used for queries); nothing stores counts. These structural/query
+views describe the parsed `source_text`; after editing, re-parse with
+`from_text(doc.reassemble())` before structural analysis.
 The surface is **one general query primitive, no blessed per-kind rollups** (DR-4):
 
 ```python
@@ -498,13 +501,17 @@ SpanRef = {
 
 - **Quote canonical, offset a hint.** Every mature annotation system (W3C `oa:Choice`,
   Hypothesis) treats the text quote as the durable anchor and offsets as accelerators,
-  because the quote survives edits and re-anchors fuzzily while offsets shift.
+  because the quote survives edits and re-anchors while offsets shift.
   Within one parse the offset is exact (the fast path); across edits the quote recovers
   the target.
-- **Resolution.** model→source is total (a node fills both span and quote); source→model
-  is exact fast-path then quote fuzzy re-anchor, updating offsets.
-- **Persistence** is quote-canonical and source-grounded; an in-memory `node_id` handle
-  is never persisted.
+- **Resolution.** model→source is total (a node fills both span and quote). source→model
+  is an exact offset fast path, then an exact quote search disambiguated by
+  prefix/suffix; `resolve()` is pure (it does not mutate the ref), and
+  `resolve_and_update()` is the explicit variant that writes the recomputed offsets back.
+  Fuzzy/edit-distance re-anchoring is deferred (not yet implemented).
+- **Persistence** is quote-canonical and source-grounded; offsets are an optional
+  position hint (`to_persisted(include_position_hint=...)`, dropped by default) and an
+  in-memory `node_id` handle is never persisted.
 - **Chrome URL Text Fragment convertible:** the quote maps to
   `#:~:text=[prefix-,]exact[,-suffix]` (a lossy projection: prose, word-boundary,
   case-insensitive), generated on demand, never stored.

--- a/src/chopdiff/docs/base_blocks.py
+++ b/src/chopdiff/docs/base_blocks.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from marko.element import Element
+
 from chopdiff.docs.block_tree import Block, parse_blocks
 from chopdiff.docs.block_types import BlockType
 
@@ -57,7 +59,9 @@ class BaseBlock:
     depth: int
 
 
-def base_blocks(text: str, *, item_partition_depth: int = 6) -> list[BaseBlock]:
+def base_blocks(
+    text: str, *, item_partition_depth: int = 6, parsed: Element | None = None
+) -> list[BaseBlock]:
     """
     Produce the flat, depth-annotated sequential block partition.
 
@@ -68,12 +72,15 @@ def base_blocks(text: str, *, item_partition_depth: int = 6) -> list[BaseBlock]:
 
     Blockquotes are always one base block regardless of depth.
 
+    `parsed` is the marko parse of `text`; pass it to reuse a shared parse, else `text`
+    is parsed here.
+
     Invariants: the result is ordered by source position, spans are non-overlapping, and
     together they cover every non-whitespace character exactly once. Exact source
     reconstruction is via each block's `source_span` (not by concatenating block text;
     see the module docstring for the continuation-content caveat).
     """
-    blocks = parse_blocks(text)
+    blocks = parse_blocks(text, parsed)
     result: list[BaseBlock] = []
     _collect_base_blocks(text, blocks, 0, item_partition_depth, result)
     return result

--- a/src/chopdiff/docs/block_tree.py
+++ b/src/chopdiff/docs/block_tree.py
@@ -56,9 +56,14 @@ class Block:
     tight: bool | None = None
 
 
-def parse_blocks(text: str) -> list[Block]:
-    """Parse `text` into a tree of structural `Block`s with exact source spans."""
-    return _blocks_from(text, flowmark_markdown().parse(text))
+def parse_blocks(text: str, parsed: Element | None = None) -> list[Block]:
+    """
+    Parse `text` into a tree of structural `Block`s with exact source spans.
+
+    `parsed` is the marko parse of `text`; pass it to reuse a shared parse (the caller
+    guarantees it is the parse of exactly this `text`), else `text` is parsed here.
+    """
+    return _blocks_from(text, parsed if parsed is not None else flowmark_markdown().parse(text))
 
 
 def walk_blocks(blocks: list[Block], _depth: int = 0) -> Iterator[tuple[Block, int]]:

--- a/src/chopdiff/docs/collect.py
+++ b/src/chopdiff/docs/collect.py
@@ -12,6 +12,7 @@ Counts, values, and groupings are left to the caller via plain Python
 
 from __future__ import annotations
 
+from collections import deque
 from collections.abc import Callable
 
 from chopdiff.docs.node import Layer, Node, NodeKind, NodeTable
@@ -41,7 +42,9 @@ def collect(
     `where`: additional predicate on each node. `recursive`: when True,
     descend into children recursively; when False, only direct children of the
     scope (or roots). `inline`: when True, include inline-kind nodes; when
-    False, exclude them. `contains`: an optional `(start, end)` span;
+    False, exclude them — but an explicit `kinds` selecting inline kinds (e.g.
+    `kinds={NodeKind.link}`) implies inline inclusion, so the common case works
+    without also passing `inline=True`. `contains`: an optional `(start, end)` span;
     restrict results to nodes whose `source_span` is within that span
     (offset-containment, the cross-layer query mechanism). `layer`: restrict to
     these parse layers (None = all layers); since the same span can appear as
@@ -57,9 +60,13 @@ def collect(
         # Non-recursive, no scope: just the root nodes.
         candidates = [table.nodes[rid] for rid in table.roots if rid in table.nodes]
 
+    # An explicit kind selection that names inline kinds implies inline inclusion,
+    # so `collect(kinds={NodeKind.link})` is not silently emptied by the inline guard.
+    include_inline = inline or (kinds is not None and bool(kinds & INLINE_KINDS))
+
     result: list[Node] = []
     for node in candidates:
-        if not inline and node.kind in INLINE_KINDS:
+        if not include_inline and node.kind in INLINE_KINDS:
             continue
         if layer is not None and node.layer not in layer:
             continue
@@ -101,14 +108,14 @@ def _subtree_nodes(table: NodeTable, scope_id: str, recursive: bool) -> list[Nod
     if not recursive:
         return [table.nodes[cid] for cid in scope_node.children if cid in table.nodes]
 
-    # BFS/DFS to collect all descendants.
+    # BFS to collect all descendants.
     result: list[Node] = []
-    stack = list(scope_node.children)
-    while stack:
-        nid = stack.pop(0)
+    queue: deque[str] = deque(scope_node.children)
+    while queue:
+        nid = queue.popleft()
         if nid not in table.nodes:
             continue
         node = table.nodes[nid]
         result.append(node)
-        stack.extend(node.children)
+        queue.extend(node.children)
     return result

--- a/src/chopdiff/docs/collect.py
+++ b/src/chopdiff/docs/collect.py
@@ -50,8 +50,10 @@ def collect(
     nodes (or all nodes when `recursive`); supplying an interval relation scans all
     nodes, so `within=section_id` needs no `recursive=True`.
 
-    `scope` is a deprecated alias for `subtree_of`; `contains` is a deprecated
-    alias for `within`. `kinds`: restrict to these `NodeKind`s (None = any).
+    `scope` is a deprecated alias for `subtree_of`; `contains` is a deprecated,
+    span-only alias for `within` (use `within` for the node-id form). Passing an
+    alias together with its modern name raises `ValueError`. `kinds`: restrict to
+    these `NodeKind`s (None = any).
     `where`: additional `Node -> bool` predicate. `inline`: include inline-kind
     nodes; an explicit `kinds` naming inline kinds (e.g. `{NodeKind.link}`) implies
     this, so the common case works without `inline=True`. `layer`: restrict to
@@ -59,6 +61,10 @@ def collect(
     layers (e.g. a `markdown` block and a `textual` paragraph), scope by `layer` to
     avoid cross-layer duplicates.
     """
+    if scope is not None and subtree_of is not None:
+        raise ValueError("pass either `subtree_of` or its deprecated alias `scope`, not both")
+    if contains is not None and within is not None:
+        raise ValueError("pass either `within` or its deprecated alias `contains`, not both")
     subtree_of = subtree_of if subtree_of is not None else scope
     within_ref = within if within is not None else contains
 

--- a/src/chopdiff/docs/collect.py
+++ b/src/chopdiff/docs/collect.py
@@ -27,37 +27,56 @@ def collect(
     table: NodeTable,
     scope: str | None = None,
     *,
+    subtree_of: str | None = None,
+    within: str | tuple[int, int] | None = None,
+    overlaps: str | tuple[int, int] | None = None,
+    contains: tuple[int, int] | None = None,
     kinds: set[NodeKind] | None = None,
     where: Callable[[Node], bool] | None = None,
     recursive: bool = False,
     inline: bool = False,
-    contains: tuple[int, int] | None = None,
     layer: set[Layer] | None = None,
 ) -> list[Node]:
     """
     Gather nodes from `table` matching the given filters, in document order.
 
-    `scope`: a node id restricting results to that node's subtree (None for
-    the whole document). `kinds`: restrict to these `NodeKind`s (None = any).
-    `where`: additional predicate on each node. `recursive`: when True,
-    descend into children recursively; when False, only direct children of the
-    scope (or roots). `inline`: when True, include inline-kind nodes; when
-    False, exclude them — but an explicit `kinds` selecting inline kinds (e.g.
-    `kinds={NodeKind.link}`) implies inline inclusion, so the common case works
-    without also passing `inline=True`. `contains`: an optional `(start, end)` span;
-    restrict results to nodes whose `source_span` is within that span
-    (offset-containment, the cross-layer query mechanism). `layer`: restrict to
-    these parse layers (None = all layers); since the same span can appear as
-    nodes in several layers (e.g. a `markdown` block and a `textual` paragraph),
-    scope by `layer` to avoid cross-layer duplicates.
+    Two distinct relations select candidates. The tree relation `subtree_of` is a
+    node id restricting results to that node's within-layer parent/child subtree
+    (`recursive` descends the whole subtree, else only direct children). The
+    interval relations are cross-layer and offset-based, each accepting a node id
+    or an explicit `(start, end)` span: `within` keeps nodes whose span is
+    contained in the region (region's span for a node id); `overlaps` keeps nodes
+    whose span intersects the region. With no relation, candidates are the root
+    nodes (or all nodes when `recursive`); supplying an interval relation scans all
+    nodes, so `within=section_id` needs no `recursive=True`.
+
+    `scope` is a deprecated alias for `subtree_of`; `contains` is a deprecated
+    alias for `within`. `kinds`: restrict to these `NodeKind`s (None = any).
+    `where`: additional `Node -> bool` predicate. `inline`: include inline-kind
+    nodes; an explicit `kinds` naming inline kinds (e.g. `{NodeKind.link}`) implies
+    this, so the common case works without `inline=True`. `layer`: restrict to
+    these parse layers (None = all); since the same span can appear in several
+    layers (e.g. a `markdown` block and a `textual` paragraph), scope by `layer` to
+    avoid cross-layer duplicates.
     """
-    if scope is not None:
-        candidates = _subtree_nodes(table, scope, recursive)
-    elif recursive:
-        # Recursive from roots: all nodes in insertion order.
+    subtree_of = subtree_of if subtree_of is not None else scope
+    within_ref = within if within is not None else contains
+
+    want_within = within_ref is not None
+    want_overlaps = overlaps is not None
+    within_region = _resolve_region(table, within_ref)
+    overlaps_region = _resolve_region(table, overlaps)
+    # A relation whose node id has no span matches nothing.
+    if (want_within and within_region is None) or (want_overlaps and overlaps_region is None):
+        return []
+
+    if subtree_of is not None:
+        candidates = _subtree_nodes(table, subtree_of, recursive)
+    elif recursive or want_within or want_overlaps:
+        # Recursive, or any interval relation: consider all nodes in insertion order.
         candidates = list(table.nodes.values())
     else:
-        # Non-recursive, no scope: just the root nodes.
+        # No relation, non-recursive: just the root nodes.
         candidates = [table.nodes[rid] for rid in table.roots if rid in table.nodes]
 
     # An explicit kind selection that names inline kinds implies inline inclusion,
@@ -72,13 +91,10 @@ def collect(
             continue
         if kinds is not None and node.kind not in kinds:
             continue
-        if contains is not None:
-            if node.source_span is None:
-                continue
-            ns, ne = node.source_span
-            cs, ce = contains
-            if not (cs <= ns and ne <= ce):
-                continue
+        if within_region is not None and not _span_within(node.source_span, within_region):
+            continue
+        if overlaps_region is not None and not _span_overlaps(node.source_span, overlaps_region):
+            continue
         if where is not None and not where(node):
             continue
         result.append(node)
@@ -95,6 +111,30 @@ def collect(
 
     result.sort(key=_sort_key)
     return result
+
+
+def _resolve_region(table: NodeTable, ref: str | tuple[int, int] | None) -> tuple[int, int] | None:
+    """Resolve an interval-relation argument to a span: a node id maps to its
+    `source_span` (None if it has none), a tuple is returned as-is."""
+    if ref is None:
+        return None
+    if isinstance(ref, str):
+        return table.nodes[ref].source_span
+    return ref
+
+
+def _span_within(span: tuple[int, int] | None, region: tuple[int, int]) -> bool:
+    """True when `span` is fully contained in `region` (subset-or-equal)."""
+    if span is None:
+        return False
+    return region[0] <= span[0] and span[1] <= region[1]
+
+
+def _span_overlaps(span: tuple[int, int] | None, region: tuple[int, int]) -> bool:
+    """True when `span` intersects `region` (half-open intervals)."""
+    if span is None:
+        return False
+    return span[0] < region[1] and region[0] < span[1]
 
 
 def _subtree_nodes(table: NodeTable, scope_id: str, recursive: bool) -> list[Node]:

--- a/src/chopdiff/docs/doc_graph.py
+++ b/src/chopdiff/docs/doc_graph.py
@@ -169,7 +169,6 @@ def build_doc_graph(
 
     # Build the node list, filtering by enabled layers (and inline detail).
     node_models: list[NodeModel] = []
-    included_ids: set[str] = set()
 
     for nid, node in table.nodes.items():
         if node.layer not in enabled_layers:
@@ -198,7 +197,8 @@ def build_doc_graph(
                 kind=node.kind.value,
                 layer=node.layer.value,
                 parent=node.parent
-                if node.parent and _is_parent_included(node.parent, table.nodes, enabled_layers)
+                if node.parent
+                and _is_parent_included(node.parent, table.nodes, enabled_layers, include_inline)
                 else None,
                 children=filtered_children,
                 source_span=span_model,
@@ -206,7 +206,6 @@ def build_doc_graph(
                 text=node_text,
             )
         )
-        included_ids.add(nid)
 
     # Build views from included nodes.
     toc_ids: list[str] = []
@@ -265,9 +264,13 @@ def _is_parent_included(
     parent_id: str,
     nodes: dict[str, Node],
     enabled_layers: frozenset[Layer],
+    include_inline: bool,
 ) -> bool:
-    """Check whether a parent node's layer is enabled."""
+    """
+    Check whether a parent node would itself be included, using the same predicate
+    as child filtering so a node never points to a parent that was omitted.
+    """
     parent = nodes.get(parent_id)
     if parent is None:
         return False
-    return parent.layer in enabled_layers
+    return _node_included(parent, enabled_layers, include_inline)

--- a/src/chopdiff/docs/interval_index.py
+++ b/src/chopdiff/docs/interval_index.py
@@ -1,0 +1,73 @@
+"""
+A lightweight per-layer index over node source spans for offset-containment
+queries, so node-table assembly does not rescan the whole table for each inline
+element. See `chopdiff.docs.node_table`.
+"""
+
+from __future__ import annotations
+
+from bisect import bisect_right
+from dataclasses import dataclass, field
+
+from chopdiff.docs.node import Layer, Node, NodeKind
+
+# One entry per spanned node: (start, end, kind, id).
+_Entry = tuple[int, int, NodeKind, str]
+
+
+@dataclass
+class _LayerEntries:
+    entries: list[_Entry] = field(default_factory=list)
+    starts: list[int] = field(default_factory=list)
+
+
+@dataclass
+class IntervalIndex:
+    """
+    Per-layer index of node spans, built once and queried for containment.
+
+    Within a layer, node spans are well-nested, so the innermost (narrowest) node
+    containing an offset is the containing node with the greatest start. Entries
+    are sorted by start; `innermost` bisects to the candidates that start at or
+    before the offset and scans back to the first that still contains it. For an
+    inline element's offset (always inside a leaf node) this returns on the first
+    step; an offset in a gap costs a short walk bounded by nesting depth, never a
+    full-table scan.
+    """
+
+    layers: dict[Layer, _LayerEntries]
+
+    @classmethod
+    def from_nodes(cls, nodes: dict[str, Node]) -> IntervalIndex:
+        layers: dict[Layer, _LayerEntries] = {}
+        for nid, node in nodes.items():
+            if node.source_span is None:
+                continue
+            le = layers.setdefault(node.layer, _LayerEntries())
+            le.entries.append((node.source_span[0], node.source_span[1], node.kind, nid))
+        for le in layers.values():
+            # Sort by start ascending, then by end descending so an enclosing node
+            # precedes the nodes it contains when their starts coincide.
+            le.entries.sort(key=lambda e: (e[0], -e[1]))
+            le.starts = [e[0] for e in le.entries]
+        return cls(layers=layers)
+
+    def innermost(self, offset: int, layer: Layer, kind: NodeKind | None = None) -> str | None:
+        """
+        The id of the narrowest node in `layer` whose span contains `offset`
+        (half-open: `start <= offset < end`), optionally restricted to `kind`,
+        or None if no such node exists.
+        """
+        le = self.layers.get(layer)
+        if le is None:
+            return None
+        # Candidates start at or before the offset; scan back to the closest one
+        # that still contains it (the deepest, i.e. narrowest, for nested spans).
+        for i in range(bisect_right(le.starts, offset) - 1, -1, -1):
+            _start, end, node_kind, nid = le.entries[i]
+            if end <= offset:
+                continue
+            if kind is not None and node_kind != kind:
+                continue
+            return nid
+        return None

--- a/src/chopdiff/docs/node.py
+++ b/src/chopdiff/docs/node.py
@@ -101,10 +101,12 @@ class NodeTable:
     A flat, id-addressed table of all parsed elements in a document, covering
     markdown, document, and textual layers over the same source text.
 
-    The table is the canonical normalized form; derived views (block tree, section
-    tree, etc.) are projections of it. Within a layer, `parent`/`children` form
-    the containment structure; cross-layer relationships use interval containment
-    via `containing()` and `contained_by()`.
+    The source string and its Unicode code-point offset space are canonical; this
+    table is the id-addressed query/serialization projection over that substrate
+    (as are the block tree, section tree, etc. — sibling projections, not derived
+    from the table). Within a layer, `parent`/`children` form the containment
+    structure; cross-layer relationships use interval containment via
+    `containing()` and `contained_by()`.
     """
 
     nodes: dict[str, Node] = field(default_factory=dict)
@@ -152,52 +154,3 @@ class NodeTable:
             for n in self.nodes.values()
             if n.source_span is not None and start <= n.source_span[0] and n.source_span[1] <= end
         ]
-
-
-## Tests
-
-
-def test_block_kinds_match_block_type_values():
-    from chopdiff.docs.block_types import BlockType
-
-    block_type_values = {bt.value for bt in BlockType}
-    block_node_kinds = {
-        nk.value
-        for nk in NodeKind
-        if nk
-        not in (
-            NodeKind.link,
-            NodeKind.code_span,
-            NodeKind.image,
-            NodeKind.inline_html,
-            NodeKind.section,
-            NodeKind.sentence,
-        )
-    }
-    assert block_node_kinds == block_type_values
-
-
-def test_inline_kinds_exist():
-    inline_kinds = {NodeKind.link, NodeKind.code_span, NodeKind.image, NodeKind.inline_html}
-    assert all(k in NodeKind for k in inline_kinds)
-    assert NodeKind.section not in inline_kinds
-    assert NodeKind.sentence not in inline_kinds
-
-
-def test_layer_nesting_covers_every_layer():
-    for layer in Layer:
-        assert layer in LAYER_NESTING, f"LAYER_NESTING missing {layer}"
-
-
-def test_nesting_guarantee_values():
-    assert LAYER_NESTING[Layer.textual] == NestingGuarantee.ordered_list
-    assert LAYER_NESTING[Layer.markdown] == NestingGuarantee.tree
-    assert LAYER_NESTING[Layer.document] == NestingGuarantee.tree
-    assert LAYER_NESTING[Layer.synthetic] == NestingGuarantee.tree
-
-
-def test_node_defaults():
-    n = Node(id="n_0001", kind=NodeKind.paragraph, layer=Layer.markdown, parent=None)
-    assert n.children == []
-    assert n.source_span is None
-    assert n.attrs == {}

--- a/src/chopdiff/docs/node_table.py
+++ b/src/chopdiff/docs/node_table.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING
 from flowmark.atomic_spans import iter_atomic_spans
 
 from chopdiff.docs.block_tree import Block
+from chopdiff.docs.interval_index import IntervalIndex
 from chopdiff.docs.node import Layer, Node, NodeKind, NodeTable
 
 if TYPE_CHECKING:
@@ -109,45 +110,6 @@ def _build_markdown_nodes(
     return child_ids
 
 
-def _find_innermost_block(offset: int, md_blocks: list[tuple[tuple[int, int], str]]) -> str | None:
-    """Find the innermost (narrowest) markdown block node containing `offset`."""
-    best: str | None = None
-    best_width = float("inf")
-    for span, nid in md_blocks:
-        if span[0] <= offset < span[1]:
-            width = span[1] - span[0]
-            if width < best_width:
-                best_width = width
-                best = nid
-    return best
-
-
-def _find_deepest_section(offset: int, nodes: dict[str, Node]) -> str | None:
-    """Find the deepest (narrowest) section node containing `offset`."""
-    best: str | None = None
-    best_width = float("inf")
-    for nid, n in nodes.items():
-        if n.layer == Layer.document and n.kind == NodeKind.section and n.source_span:
-            s, e = n.source_span
-            if s <= offset < e and (e - s) < best_width:
-                best_width = e - s
-                best = nid
-    return best
-
-
-def _find_sentence_node(offset: int, nodes: dict[str, Node]) -> str | None:
-    """Find the narrowest textual-layer sentence node containing `offset`."""
-    best: str | None = None
-    best_width = float("inf")
-    for nid, n in nodes.items():
-        if n.layer == Layer.textual and n.kind == NodeKind.sentence and n.source_span:
-            s, e = n.source_span
-            if s <= offset < e and (e - s) < best_width:
-                best_width = e - s
-                best = nid
-    return best
-
-
 def _build_inline_nodes(
     source_text: str,
     doc: TextDoc,
@@ -162,13 +124,10 @@ def _build_inline_nodes(
     node's parent is its containing block node; section and sentence associations
     are stored in `attrs`.
     """
-    # Sorted list of markdown block nodes for parent lookup.
-    md_blocks: list[tuple[tuple[int, int], str]] = [
-        (n.source_span, nid)
-        for nid, n in all_nodes.items()
-        if n.layer == Layer.markdown and n.source_span is not None
-    ]
-    md_blocks.sort(key=lambda x: (x[0][0], -x[0][1]))
+    # Index the structural/section/sentence nodes built so far (inline nodes are
+    # not yet added) for offset-containment lookups, avoiding a full-table scan per
+    # inline element.
+    index = IntervalIndex.from_nodes(all_nodes)
 
     seen_spans: set[tuple[int, int]] = set()
 
@@ -179,15 +138,15 @@ def _build_inline_nodes(
                 continue
             seen_spans.add(link.span)
             nid = _next_id(counter)
-            parent = _find_innermost_block(link.span[0], md_blocks)
+            parent = index.innermost(link.span[0], Layer.markdown)
             attrs: dict[str, object] = {"url": link.url, "text": link.text}
             if link.title:
                 attrs["title"] = link.title
 
-            section_id = _find_deepest_section(link.span[0], all_nodes)
+            section_id = index.innermost(link.span[0], Layer.document, kind=NodeKind.section)
             if section_id:
                 attrs["section"] = section_id
-            sent_nid = _find_sentence_node(link.span[0], all_nodes)
+            sent_nid = index.innermost(link.span[0], Layer.textual, kind=NodeKind.sentence)
             if sent_nid:
                 attrs["sentence"] = sent_nid
 
@@ -249,7 +208,7 @@ def _build_inline_nodes(
         seen_spans.add(span)
 
         nid = _next_id(counter)
-        parent = _find_innermost_block(span[0], md_blocks)
+        parent = index.innermost(span[0], Layer.markdown)
         inline_attrs: dict[str, object] = {}
         if kind == NodeKind.code_span:
             content = atomic.text
@@ -271,10 +230,10 @@ def _build_inline_nodes(
             if bracket_start >= 0 and bracket_end > bracket_start:
                 inline_attrs["text"] = text[bracket_start + 1 : bracket_end]
 
-        section_id = _find_deepest_section(span[0], all_nodes)
+        section_id = index.innermost(span[0], Layer.document, kind=NodeKind.section)
         if section_id:
             inline_attrs["section"] = section_id
-        sent_nid = _find_sentence_node(span[0], all_nodes)
+        sent_nid = index.innermost(span[0], Layer.textual, kind=NodeKind.sentence)
         if sent_nid:
             inline_attrs["sentence"] = sent_nid
 

--- a/src/chopdiff/docs/node_table.py
+++ b/src/chopdiff/docs/node_table.py
@@ -6,8 +6,10 @@ covering three layers (markdown, document, textual) over the same source text.
 is cached lazily on `TextDoc.node_table()` (safe because `source_text` is
 immutable after parse).
 
-The node table is the canonical normalized form from which derived views
-(block tree, section tree, inline index, etc.) are cheap projections.
+The source string and its offset space are canonical; the node table is the
+id-addressed query/serialization projection over that substrate, assigning ids
+and layer tags. The block tree, section tree, and inline index are sibling
+projections sharing the same source/offset substrate.
 """
 
 # pyright: reportImportCycles=false

--- a/src/chopdiff/docs/span_ref.py
+++ b/src/chopdiff/docs/span_ref.py
@@ -11,11 +11,22 @@ survives reparsing and re-anchors after edits that shift offsets.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from urllib.parse import quote
 
 from chopdiff.docs.node import Node
 
 # Default context window size for prefix/suffix capture.
 _CONTEXT_WINDOW = 24
+
+
+def _encode_fragment_part(text: str) -> str:
+    """
+    Percent-encode one component of a `#:~:text=` fragment. Encodes everything
+    that is not unreserved, and additionally `-` and `,` (which are structural
+    delimiters in the fragment grammar) so component text can never be mistaken
+    for a `prefix-,` / `,-suffix` boundary.
+    """
+    return quote(text, safe="").replace("-", "%2D").replace(",", "%2C")
 
 
 @dataclass
@@ -58,37 +69,46 @@ class SpanRef:
         suffix = source_text[end:suffix_end] if end < suffix_end else None
         return cls(exact=exact, prefix=prefix, suffix=suffix, start=start, end=end)
 
-    def to_persisted(self) -> SpanRef:
+    def to_persisted(self, *, include_position_hint: bool = False) -> SpanRef:
         """
-        Return a copy suitable for persistence: quote-canonical with no transient
-        offsets. The persisted form references text, not positions.
+        Return a copy suitable for persistence. The quote (`exact`/`prefix`/`suffix`)
+        is the durable anchor; offsets are valid only within the exact source they
+        were computed from, so by default they are dropped (`include_position_hint`
+        keeps them as a fast-path hint when persisting alongside that same source).
         """
-        return SpanRef(exact=self.exact, prefix=self.prefix, suffix=self.suffix)
+        return SpanRef(
+            exact=self.exact,
+            prefix=self.prefix,
+            suffix=self.suffix,
+            start=self.start if include_position_hint else None,
+            end=self.end if include_position_hint else None,
+        )
 
     def to_text_fragment(self) -> str:
         """
         Produce a Chrome-style `#:~:text=` URL text-fragment directive.
-        Format: `#:~:text=[prefix-,]exact[,-suffix]`.
-        This is a lossy projection (prose, word-boundary, case-insensitive).
+        Format: `#:~:text=[prefix-,]exact[,-suffix]`, with each component
+        percent-encoded. This is a lossy projection (prose, word-boundary,
+        case-insensitive).
         """
         parts: list[str] = []
         if self.prefix:
-            parts.append(f"{self.prefix}-,")
-        parts.append(self.exact)
+            parts.append(f"{_encode_fragment_part(self.prefix)}-,")
+        parts.append(_encode_fragment_part(self.exact))
         if self.suffix:
-            parts.append(f",-{self.suffix}")
+            parts.append(f",-{_encode_fragment_part(self.suffix)}")
         return "#:~:text=" + "".join(parts)
 
 
 def resolve(span_ref: SpanRef, source_text: str) -> tuple[int, int] | None:
     """
     Resolve a `SpanRef` against `source_text`, returning the `(start, end)`
-    offsets or None if the span cannot be found.
+    offsets or None if the span cannot be found. Pure: it does not mutate
+    `span_ref` (use `resolve_and_update` to also write the offsets back).
 
     Fast path: if `start`/`end` are present and the text at those offsets
     matches `exact`, return immediately. Otherwise, search the full text for
-    `exact`, disambiguating with `prefix`/`suffix` if needed, and update
-    the `SpanRef`'s offsets in place.
+    `exact`, disambiguating with `prefix`/`suffix` if needed.
     """
     # Fast path: offsets are valid.
     if span_ref.start is not None and span_ref.end is not None:
@@ -120,12 +140,20 @@ def resolve(span_ref: SpanRef, source_text: str) -> tuple[int, int] | None:
         # Disambiguate with prefix/suffix scoring.
         best = _best_match(occurrences, exact, span_ref.prefix, span_ref.suffix, source_text)
 
-    start = best
-    end = best + len(exact)
-    # Update offsets in place for future fast-path use.
-    span_ref.start = start
-    span_ref.end = end
-    return (start, end)
+    return (best, best + len(exact))
+
+
+def resolve_and_update(span_ref: SpanRef, source_text: str) -> tuple[int, int] | None:
+    """
+    Resolve a `SpanRef` and, on success, write the recomputed offsets back into
+    `span_ref.start`/`span_ref.end` so subsequent resolves hit the fast path.
+    Returns the `(start, end)` offsets or None. The mutating counterpart to
+    `resolve()`.
+    """
+    result = resolve(span_ref, source_text)
+    if result is not None:
+        span_ref.start, span_ref.end = result
+    return result
 
 
 def _best_match(

--- a/src/chopdiff/docs/text_doc.py
+++ b/src/chopdiff/docs/text_doc.py
@@ -454,7 +454,7 @@ class TextDoc:
     """
     A class for parsing and handling documents consisting of sentences and paragraphs
     of text. Preserves original text, tracking offsets of each sentence and paragraph.
-    Compatible with Markdown and Markown with HTML tags.
+    Compatible with Markdown and Markdown with HTML tags.
 
     Contract and intended use:
 
@@ -717,9 +717,14 @@ class TextDoc:
         return self.paragraphs[index.para_index].sentences[index.sent_index]
 
     def set_sent(self, index: SentIndex, sent_str: str) -> None:
+        # Preserve the replaced sentence's `original_text` so its `span` keeps
+        # pointing at the original source slice (the documented contract: source
+        # references describe the original blocks, not the edited content, which
+        # lives in `text`). Dropping it would make `span` describe the new text's
+        # length at the old offset, i.e. neither the old nor a valid source slice.
         old_sent = self.get_sent(index)
         self.paragraphs[index.para_index].sentences[index.sent_index] = Sentence(
-            sent_str, old_sent.offsets
+            sent_str, old_sent.offsets, original_text=old_sent.original_text
         )
 
     def seek_to_sent(self, offset: int, unit: TextUnit) -> tuple[SentIndex, int]:

--- a/src/chopdiff/docs/text_doc.py
+++ b/src/chopdiff/docs/text_doc.py
@@ -1,19 +1,20 @@
 from __future__ import annotations
 
+import threading
 from bisect import bisect_left
 from collections import Counter, defaultdict
 from collections.abc import Callable, Generator, Iterable, Iterator
 from copy import deepcopy
 from dataclasses import dataclass, field
-from functools import cached_property
-from typing import TypeAlias
+from functools import cached_property, wraps
+from typing import TypeAlias, TypeVar
 
 import regex
 from flowmark import flowmark_markdown, split_sentences_regex
 from flowmark.atomic_spans import iter_atomic_spans, split_sentences_with_spans
 from flowmark.markdown_ast import extract_links
 from funlog import tally_calls
-from marko.block import BlankLine, Heading, SetextHeading
+from marko.block import BlankLine, Document, Heading, SetextHeading
 from typing_extensions import override
 
 from chopdiff.docs.base_blocks import BaseBlock, base_blocks
@@ -142,7 +143,7 @@ class Link:
     span: tuple[int, int] | None
 
 
-def _block_links(block_text: str, doc_offset: int) -> list[Link]:
+def _block_links(block_text: str, doc_offset: int, *, parsed: Document | None = None) -> list[Link]:
     """
     Links in a text region. Identity comes from `extract_links` (always correct,
     including reference links resolved against definitions anywhere in the region);
@@ -154,8 +155,14 @@ def _block_links(block_text: str, doc_offset: int) -> list[Link]:
     A forward character cursor (`char_cursor`) advances past each located span so that
     bracketed matches, autolinks, bare URLs, and repeated URLs resolve in document order
     without one no-span identity desyncing the next.
+
+    `parsed` is the marko parse of `block_text`; pass it to reuse a shared parse (the
+    caller guarantees it is the parse of exactly this `block_text`), else it is parsed
+    here.
     """
-    identities = extract_links(flowmark_markdown().parse(block_text))
+    identities = extract_links(
+        parsed if parsed is not None else flowmark_markdown().parse(block_text)
+    )
     # Only `markdown_link` atomics are bracketed `[...]` link constructs; autolinks come
     # through as `html_open_tag` and bare URLs are not atomic, so both are handled by the
     # literal fallback below.
@@ -450,6 +457,43 @@ class Paragraph:
         return _block_links(self.original_text, self.offsets.doc_offset)
 
 
+_DerivedT = TypeVar("_DerivedT")
+
+
+def _memoized_derivation(
+    attr_name: str,
+) -> Callable[[Callable[[TextDoc], _DerivedT]], Callable[[TextDoc], _DerivedT]]:
+    """
+    Memoize a zero-arg `TextDoc` derivation into `attr_name`, computed at most once.
+
+    Filling the cache is the only state change that happens during a read, and it is
+    idempotent and thread-safe: a lock-free fast path returns an already-cached value,
+    otherwise the instance's reentrant lock serializes the first computation so
+    concurrent readers compute it once and all observe the same object. This is sound
+    only because every memoized derivation is a pure, deterministic function of the
+    immutable-after-parse `source_text` (see the `TextDoc` contract); the lock is
+    reentrant so a derivation may call other memoized derivations (e.g. `node_table()`
+    uses `blocks()` and `links()`).
+    """
+
+    def decorator(func: Callable[[TextDoc], _DerivedT]) -> Callable[[TextDoc], _DerivedT]:
+        @wraps(func)
+        def wrapper(self: TextDoc) -> _DerivedT:
+            cached = getattr(self, attr_name)
+            if cached is not None:
+                return cached
+            with self._cache_lock:
+                cached = getattr(self, attr_name)
+                if cached is None:
+                    cached = func(self)
+                    setattr(self, attr_name, cached)
+                return cached
+
+        return wrapper
+
+    return decorator
+
+
 @dataclass
 class TextDoc:
     """
@@ -491,25 +535,58 @@ class TextDoc:
       (their offsets still point into it). Docs built from synthetic content
       (`from_wordtoks`) set it to the reassembled text. `block_at_offset` /
       `sentence_at_offset` map an absolute offset back to the unit that contains it.
+
+    - Read-time thread-safety. The derived views — `blocks()`, `links()`, `sections()`,
+      `base_blocks()`, `node_table()`, `graph()`, `collect()`, and the size/TOC helpers —
+      are read-only with respect to your data: they are pure, deterministic functions of
+      `source_text` and never mutate paragraphs or sentences. The *only* state change
+      during such a read is idempotent population of internal caches. The document-level
+      caches (the shared marko parse, the block tree, the link list, the node table) are
+      filled under a per-instance reentrant lock, so concurrent readers compute each at
+      most once and all observe the same value. A few per-element values (e.g.
+      `Paragraph.block_type`) are memoized with `cached_property`, which is not lock-
+      guarded but is equally idempotent and deterministic — a pure function of that
+      element's immutable `original_text` — so a concurrent recompute is harmless (it
+      yields the same value). Because every derivation is deterministic, the result is
+      identical whether or not a cache was warm and regardless of read order. The
+      *editing* methods (`set_sent`, `replace_str`, `append_sent`, `sub_doc`, `filtered`,
+      etc.) do mutate and are not thread-safe; do not edit a document while another thread
+      reads it. Editing also does not invalidate the source-backed caches (they remain
+      keyed to the parsed `source_text`); re-parse with `from_text(doc.reassemble())` to
+      analyze edited content.
     """
 
     paragraphs: list[Paragraph]
     source_text: str = ""
+    # Reentrant lock guarding idempotent cache population (see the class contract and
+    # `_memoized_derivation`). Per-instance so reads of different documents never contend;
+    # reentrant so a derivation may use other memoized derivations.
+    _cache_lock: threading.RLock = field(
+        default_factory=threading.RLock, init=False, compare=False, repr=False
+    )
+    _cached_parsed: Document | None = field(default=None, init=False, compare=False, repr=False)
     _cached_node_table: NodeTable | None = field(
         default=None, init=False, compare=False, repr=False
     )
     _cached_blocks: list[Block] | None = field(default=None, init=False, compare=False, repr=False)
     _cached_links: list[Link] | None = field(default=None, init=False, compare=False, repr=False)
 
+    @_memoized_derivation("_cached_parsed")
+    def _parsed(self) -> Document:
+        """
+        The single shared marko parse of `source_text`, computed once. `blocks()` and
+        `links()` (and `base_blocks()`) derive from this one parse rather than each
+        re-parsing the whole document. See the class contract on read-time caching.
+        """
+        return flowmark_markdown().parse(self.source_text or self.reassemble())
+
+    @_memoized_derivation("_cached_node_table")
     def node_table(self) -> NodeTable:
         """
-        Lazily build and cache the node table for this document. The table is a pure
-        function of the immutable `source_text`, so it is computed once and reused.
+        The node table for this document, computed once and cached. A pure function of
+        the immutable `source_text` (see the class contract on read-time caching).
         """
-        if self._cached_node_table is None:
-            self._cached_node_table = build_node_table(self)
-        assert self._cached_node_table is not None
-        return self._cached_node_table
+        return build_node_table(self)
 
     @classmethod
     @tally_calls(level="warning", min_total_runtime=5)
@@ -649,36 +726,38 @@ class TextDoc:
             stack.append(section)
         return roots
 
+    @_memoized_derivation("_cached_links")
+    def _link_list(self) -> list[Link]:
+        return _block_links(self.source_text or self.reassemble(), 0, parsed=self._parsed())
+
     def links(self) -> list[Link]:
         """
-        All links in the document, in document order. Parsed from `source_text` once so
-        that reference-style links (`[text][ref]` with `[ref]: url` in a separate block)
-        resolve correctly. Lazily cached so per-section link rollups share one parse;
-        returns a fresh shallow copy each call so mutating the result cannot poison the
+        All links in the document, in document order. Derived from the document's single
+        shared parse (see the class contract on read-time caching), so reference-style
+        links (`[text][ref]` with `[ref]: url` in a separate block) resolve correctly.
+        Returns a fresh shallow copy each call so mutating the result cannot poison the
         cache (`Link` is frozen, so the shared elements are safe). See `Link`.
         """
-        if self._cached_links is None:
-            self._cached_links = _block_links(self.source_text or self.reassemble(), 0)
-        return list(self._cached_links)
+        return list(self._link_list())
+
+    @_memoized_derivation("_cached_blocks")
+    def _block_list(self) -> list[Block]:
+        return parse_blocks(self.source_text or self.reassemble(), self._parsed())
 
     def blocks(self) -> list[Block]:
         """
         The document's structural block tree (opt-in), with exact source spans. Unlike
         the blank-line `paragraphs`, this keeps a fenced code block whole (even with
         internal blank lines) and decomposes a tight list into `list_item`s with nested
-        sublists. Parsed from `source_text` (or the reassembled text if absent). See
-        `chopdiff.docs.block_tree`.
+        sublists. Derived from the document's single shared parse (see the class contract
+        on read-time caching), so `sections()`, `links()`, and the node table all reuse
+        one parse. See `chopdiff.docs.block_tree`.
 
-        Lazily cached on the immutable `source_text` (sentence edits touch the editing
-        view, not `source_text`), so derived views (`sections()`, the node table) can
-        share one parse rather than re-parsing. Returns a fresh shallow copy of the
-        cached list each call, so reordering/filtering the result cannot poison the
-        shared cache; the `Block` objects themselves are shared and must be treated as
-        read-only.
+        Returns a fresh shallow copy of the cached list each call, so reordering/filtering
+        the result cannot poison the shared cache; the `Block` objects themselves are
+        shared and must be treated as read-only.
         """
-        if self._cached_blocks is None:
-            self._cached_blocks = parse_blocks(self.source_text or self.reassemble())
-        return list(self._cached_blocks)
+        return list(self._block_list())
 
     def base_blocks(self, *, item_partition_depth: int = 6) -> list[BaseBlock]:
         """
@@ -687,10 +766,13 @@ class TextDoc:
         (except normalized paragraph-break whitespace). A thin method over the
         `chopdiff.docs.base_blocks.base_blocks` free function; see it for the
         `item_partition_depth` semantics. Distinct from `blocks()`, which is the
-        recursive structural tree (a query view, not a partition).
+        recursive structural tree (a query view, not a partition). Reuses the document's
+        single shared parse.
         """
         return base_blocks(
-            self.source_text or self.reassemble(), item_partition_depth=item_partition_depth
+            self.source_text or self.reassemble(),
+            item_partition_depth=item_partition_depth,
+            parsed=self._parsed(),
         )
 
     def block_type_counts(self) -> Counter[BlockType]:

--- a/src/chopdiff/docs/text_doc.py
+++ b/src/chopdiff/docs/text_doc.py
@@ -7,7 +7,7 @@ from collections.abc import Callable, Generator, Iterable, Iterator
 from copy import deepcopy
 from dataclasses import dataclass, field
 from functools import cached_property, wraps
-from typing import NamedTuple, TypeAlias, TypeVar
+from typing import NamedTuple, TypeAlias, TypeVar, cast
 
 import regex
 from flowmark import flowmark_markdown, split_sentences_regex
@@ -572,6 +572,23 @@ class TextDoc:
     _cached_blocks: list[Block] | None = field(default=None, init=False, compare=False, repr=False)
     _cached_links: list[Link] | None = field(default=None, init=False, compare=False, repr=False)
 
+    @override
+    def __getstate__(self) -> dict[str, object]:
+        # Pickle/deepcopy only the source data. The reentrant lock is not pickleable and
+        # the derived caches (incl. the marko parse) re-derive on demand, so both are
+        # dropped here and recreated in `__setstate__`. This keeps `TextDoc` copyable and
+        # picklable despite holding a lock.
+        return {"paragraphs": self.paragraphs, "source_text": self.source_text}
+
+    def __setstate__(self, state: dict[str, object]) -> None:
+        self.paragraphs = cast("list[Paragraph]", state["paragraphs"])
+        self.source_text = cast(str, state["source_text"])
+        self._cache_lock = threading.RLock()
+        self._cached_parsed = None
+        self._cached_node_table = None
+        self._cached_blocks = None
+        self._cached_links = None
+
     @_memoized_derivation("_cached_parsed")
     def _parsed(self) -> Document:
         """
@@ -779,8 +796,9 @@ class TextDoc:
     def block_type_counts(self) -> Counter[BlockType]:
         """
         Tally of top-level structural block types in the document. A derived view over
-        `blocks()` (no stored counts), density-invariant by construction — `Counter` over
-        the live block tree, so it always reflects current content.
+        `blocks()` (no stored counts), density-invariant by construction. Like all
+        structural views it describes the parsed `source_text` (see the class contract),
+        not in-place sentence edits; re-parse to tally edited content.
         """
         return Counter(block.type for block in self.blocks())
 

--- a/src/chopdiff/docs/text_doc.py
+++ b/src/chopdiff/docs/text_doc.py
@@ -7,7 +7,7 @@ from collections.abc import Callable, Generator, Iterable, Iterator
 from copy import deepcopy
 from dataclasses import dataclass, field
 from functools import cached_property, wraps
-from typing import TypeAlias, TypeVar
+from typing import NamedTuple, TypeAlias, TypeVar
 
 import regex
 from flowmark import flowmark_markdown, split_sentences_regex
@@ -71,12 +71,13 @@ def is_markdown_header(markdown: str) -> bool:
     return regex.match(r"^#+ ", markdown) is not None
 
 
-def _heading_element(text: str) -> Heading | SetextHeading | None:
-    parsed = flowmark_markdown().parse(text)
-    for element in parsed.children:
-        if isinstance(element, (Heading, SetextHeading)):
-            return element
-    return None
+class _BlockInfo(NamedTuple):
+    """A paragraph's classification from one parse: its `BlockType` and, for headings,
+    the level and title. Caches the small derived values, not the marko `Document`."""
+
+    block_type: BlockType
+    heading_level: int | None
+    heading_title: str | None
 
 
 def _inline_text(element: object) -> str:
@@ -419,38 +420,38 @@ class Paragraph:
         return FOOTNOTE_DEF_REGEX.match(initial_text) is not None
 
     @cached_property
-    def block_type(self) -> BlockType:
+    def _block_info(self) -> _BlockInfo:
         """
-        Classify this block by its Markdown kind. See `BlockType` for caveats about
-        blank-line splitting (e.g. a list is one block, not one block per item).
-
-        Cached: derived from `original_text`, which does not change after parsing.
+        Classify this paragraph and extract heading level/title from a single parse of
+        `original_text` (which does not change after parsing). Cached; the marko document
+        is not retained. See `BlockType` for blank-line-splitting caveats.
         """
         text = self.original_text.strip()
         if not text:
-            return BlockType.paragraph
+            return _BlockInfo(BlockType.paragraph, None, None)
         parsed = flowmark_markdown().parse(text)
         element = next((el for el in parsed.children if not isinstance(el, BlankLine)), None)
         block_type = block_type_for(element) if element is not None else BlockType.paragraph
         # marko treats a single-line HTML tag as an inline-HTML paragraph rather than
         # an HTML block, so fall back to chopdiff's own markup check for those.
         if block_type == BlockType.paragraph and self.is_markup():
-            return BlockType.html
-        return block_type
+            block_type = BlockType.html
+        if isinstance(element, (Heading, SetextHeading)):
+            return _BlockInfo(block_type, element.level, _inline_text(element).strip())
+        return _BlockInfo(block_type, None, None)
+
+    @property
+    def block_type(self) -> BlockType:
+        """This paragraph's Markdown block kind (see `_block_info`)."""
+        return self._block_info.block_type
 
     def heading_level(self) -> int | None:
         """The Markdown heading level (1-6) if this block is a heading, else None."""
-        if self.block_type != BlockType.heading:
-            return None
-        element = _heading_element(self.original_text.strip())
-        return element.level if element is not None else None
+        return self._block_info.heading_level
 
     def heading_title(self) -> str | None:
         """The heading text without `#` markers if this block is a heading, else None."""
-        if self.block_type != BlockType.heading:
-            return None
-        element = _heading_element(self.original_text.strip())
-        return _inline_text(element).strip() if element is not None else None
+        return self._block_info.heading_title
 
     def links(self) -> list[Link]:
         """Links in this block, in order (identity always; absolute span when recoverable)."""

--- a/src/chopdiff/docs/text_doc.py
+++ b/src/chopdiff/docs/text_doc.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from bisect import bisect_left
 from collections import Counter, defaultdict
 from collections.abc import Callable, Generator, Iterable, Iterator
 from copy import deepcopy
@@ -605,13 +606,28 @@ class TextDoc:
         The heading hierarchy as a tree of top-level `Section`s. A section owns the
         blocks from its heading up to the next heading of equal-or-higher level; deeper
         headings become nested `children`. Content before the first heading (preamble)
-        belongs to no section. Derived from heading levels; no whole-document re-parse.
+        belongs to no section.
+
+        Headings come from the structural parse — top-level `heading` blocks of
+        `blocks()` — not the blank-line paragraph view, so a `#`-prefixed line that the
+        paragraph splitter isolates from inside a fenced code block is not mistaken for a
+        section heading, and headings nested in blockquotes or list items (which are not
+        top-level blocks) do not start document sections.
         """
         source_text = self.source_text or self.reassemble()
+        # Start offsets of top-level structural heading blocks, sorted for bisect lookup.
+        heading_starts = sorted(
+            block.span[0] for block in self.blocks() if block.type == BlockType.heading
+        )
         roots: list[Section] = []
         stack: list[Section] = []
         for para in self.paragraphs:
-            level = para.heading_level()
+            # A paragraph is a heading iff its span contains a top-level structural
+            # heading start (a real ATX/setext heading is one paragraph and one block).
+            para_start, para_end = para.span
+            idx = bisect_left(heading_starts, para_start)
+            is_heading = idx < len(heading_starts) and heading_starts[idx] < para_end
+            level = para.heading_level() if is_heading else None
             if level is None:
                 if stack:
                     stack[-1].content.append(para)
@@ -976,11 +992,14 @@ class TextDoc:
         self,
         scope: str | None = None,
         *,
+        subtree_of: str | None = None,
+        within: str | tuple[int, int] | None = None,
+        overlaps: str | tuple[int, int] | None = None,
+        contains: tuple[int, int] | None = None,
         kinds: set[NodeKind] | None = None,
         where: Callable[[Node], bool] | None = None,
         recursive: bool = False,
         inline: bool = False,
-        contains: tuple[int, int] | None = None,
         layer: set[Layer] | None = None,
     ) -> list[Node]:
         """
@@ -990,11 +1009,14 @@ class TextDoc:
         return _collect(
             self.node_table(),
             scope,
+            subtree_of=subtree_of,
+            within=within,
+            overlaps=overlaps,
+            contains=contains,
             kinds=kinds,
             where=where,
             recursive=recursive,
             inline=inline,
-            contains=contains,
             layer=layer,
         )
 

--- a/tests/docs/test_caching_threadsafe.py
+++ b/tests/docs/test_caching_threadsafe.py
@@ -1,0 +1,91 @@
+"""
+Read-time caching contract for `TextDoc`: derivations are pure functions of the
+immutable source, cache population is the only state change during a read, and that
+population is idempotent, deterministic, and thread-safe (computed at most once even
+under concurrent access).
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import marko.parser as marko_parser
+
+from chopdiff.docs.block_tree import parse_blocks
+from chopdiff.docs.text_doc import TextDoc, _block_links
+
+_TEXT = (
+    "# Title\n\n"
+    + "\n\n".join(
+        f"Paragraph {i} has a [link{i}](https://example.com/{i}) and `code{i}` inline. "
+        f"It also has a second sentence number {i}."
+        for i in range(60)
+    )
+    + "\n\n## Subsection\n\nClosing paragraph with [final](https://example.com/final).\n"
+)
+
+
+def test_shared_parse_matches_independent_parses():
+    """blocks() and links() derived from the one shared parse equal independent parses."""
+    doc = TextDoc.from_text(_TEXT)
+    assert [(b.type, b.span) for b in doc.blocks()] == [
+        (b.type, b.span) for b in parse_blocks(_TEXT)
+    ]
+    assert doc.links() == _block_links(_TEXT, 0)
+
+
+def test_read_order_does_not_change_results():
+    """Deriving links before blocks gives the same values as blocks before links."""
+    d1 = TextDoc.from_text(_TEXT)
+    b1 = [(b.type, b.span) for b in d1.blocks()]
+    l1 = d1.links()
+
+    d2 = TextDoc.from_text(_TEXT)
+    l2 = d2.links()
+    b2 = [(b.type, b.span) for b in d2.blocks()]
+
+    assert b1 == b2
+    assert l1 == l2
+
+
+def test_caches_are_identity_stable_but_public_views_are_copies():
+    doc = TextDoc.from_text(_TEXT)
+    assert doc.node_table() is doc.node_table()
+    assert doc._parsed() is doc._parsed()
+    # Public blocks() returns a fresh list each call (so callers cannot poison the cache)
+    # whose shared elements are equal.
+    first, second = doc.blocks(), doc.blocks()
+    assert first is not second
+    assert first == second
+
+
+def test_concurrent_reads_parse_once_and_return_one_table():
+    """Under concurrent first access, the document is fully parsed exactly once and every
+    reader observes the same cached node table."""
+    doc = TextDoc.from_text(_TEXT)
+    assert len(_TEXT) > 2000  # ensures the full-doc parse is distinguishable by length
+
+    original_parse = marko_parser.Parser.parse
+    full_doc_parses = 0
+    count_lock = threading.Lock()
+
+    def counting_parse(self: marko_parser.Parser, text: str):  # type: ignore[no-untyped-def]
+        if len(text) > 2000:
+            nonlocal full_doc_parses
+            with count_lock:
+                full_doc_parses += 1
+        return original_parse(self, text)
+
+    def read_table_id(_: int) -> int:
+        return id(doc.node_table())
+
+    marko_parser.Parser.parse = counting_parse  # type: ignore[method-assign]
+    try:
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            table_ids = list(pool.map(read_table_id, range(32)))
+    finally:
+        marko_parser.Parser.parse = original_parse  # type: ignore[method-assign]
+
+    assert len(set(table_ids)) == 1
+    assert full_doc_parses == 1

--- a/tests/docs/test_caching_threadsafe.py
+++ b/tests/docs/test_caching_threadsafe.py
@@ -7,6 +7,8 @@ under concurrent access).
 
 from __future__ import annotations
 
+import copy
+import pickle
 import threading
 from concurrent.futures import ThreadPoolExecutor
 
@@ -89,3 +91,32 @@ def test_concurrent_reads_parse_once_and_return_one_table():
 
     assert len(set(table_ids)) == 1
     assert full_doc_parses == 1
+
+
+def test_textdoc_deepcopy_and_pickle_cold_and_warm():
+    """The per-instance lock must not break value semantics: TextDoc stays deep-copyable
+    and picklable, both before and after its caches are warmed (caches/lock are dropped
+    and re-derived on the copy)."""
+    doc = TextDoc.from_text(_TEXT)
+
+    # Cold: no caches warmed yet.
+    assert copy.deepcopy(doc) == doc
+    assert pickle.loads(pickle.dumps(doc)) == doc
+
+    # Warm the caches, then copy/pickle.
+    doc.node_table()
+    doc.blocks()
+    doc.links()
+
+    warm_copy = copy.deepcopy(doc)
+    assert warm_copy == doc
+    assert warm_copy.reassemble() == doc.reassemble()
+    # The copy re-derives its own caches rather than sharing the original's objects.
+    assert warm_copy.node_table() is not doc.node_table()
+    assert [(b.type, b.span) for b in warm_copy.blocks()] == [
+        (b.type, b.span) for b in doc.blocks()
+    ]
+
+    restored = pickle.loads(pickle.dumps(doc))
+    assert restored == doc
+    assert restored.links() == doc.links()

--- a/tests/docs/test_collect.py
+++ b/tests/docs/test_collect.py
@@ -307,6 +307,51 @@ def test_doc_collect_links_in_section_matches_spec_example():
     assert "https://one.example.com" not in two_urls
 
 
+def test_within_node_id_scopes_cross_layer_without_recursive():
+    """`within=section_id` gathers cross-layer matches inside the section's span and
+    needs no `recursive=True`."""
+    doc = TextDoc.from_text(_RICH_DOC)
+    table = doc.node_table()
+    sec_two = next(
+        n
+        for n in table.nodes.values()
+        if n.kind == NodeKind.section and n.attrs.get("title") == "Section Two"
+    )
+    links = doc.collect(within=sec_two.id, kinds={NodeKind.link})
+    assert {n.attrs.get("url") for n in links} == {"https://two.example.com"}
+
+
+def test_contains_is_deprecated_alias_for_within():
+    doc = TextDoc.from_text(_RICH_DOC)
+    section_one = doc.sections()[0]
+    via_within = doc.collect(within=section_one.span, kinds={NodeKind.link}, recursive=True)
+    via_contains = doc.collect(contains=section_one.span, kinds={NodeKind.link}, recursive=True)
+    assert [n.id for n in via_within] == [n.id for n in via_contains]
+
+
+def test_subtree_of_is_alias_for_scope():
+    doc = TextDoc.from_text(_RICH_DOC)
+    bq = next(n for n in doc.node_table().nodes.values() if n.kind == NodeKind.blockquote)
+    via_scope = doc.collect(scope=bq.id, recursive=True)
+    via_subtree = doc.collect(subtree_of=bq.id, recursive=True)
+    assert [n.id for n in via_scope] == [n.id for n in via_subtree]
+
+
+def test_overlaps_matches_only_intersecting_spans():
+    """`overlaps` keeps nodes whose span intersects the region (not just containment)."""
+    doc = TextDoc.from_text("# Title\n\nBody paragraph here.")
+    # "# Title" is 0:7; the body paragraph starts at 9. A region straddling the gap
+    # intersects both blocks.
+    straddle = doc.collect(overlaps=(5, 12), layer={Layer.markdown}, recursive=True)
+    kinds = {n.kind for n in straddle}
+    assert NodeKind.heading in kinds
+    assert NodeKind.paragraph in kinds
+
+    # A region wholly inside the heading does not reach the paragraph.
+    heading_only = doc.collect(overlaps=(0, 3), layer={Layer.markdown}, recursive=True)
+    assert all(n.kind != NodeKind.paragraph for n in heading_only)
+
+
 def test_textdoc_base_blocks_matches_free_function():
     from chopdiff.docs.base_blocks import base_blocks as base_blocks_fn
 

--- a/tests/docs/test_collect.py
+++ b/tests/docs/test_collect.py
@@ -292,16 +292,16 @@ def test_collect_layer_does_not_silently_drop_sections():
 
 
 def test_doc_collect_links_in_section_matches_spec_example():
-    """The spec §9 recipe: doc.collect(contains=section.span, kinds={link}, recursive=True)."""
+    """The spec §9 recipe: doc.collect(within=section.span, kinds={link})."""
     doc = TextDoc.from_text(_RICH_DOC)
     section_one = doc.sections()[0]
     section_two = section_one.children[0]
 
-    one_links = doc.collect(contains=section_one.span, kinds={NodeKind.link}, recursive=True)
+    one_links = doc.collect(within=section_one.span, kinds={NodeKind.link})
     assert "https://one.example.com" in [n.attrs.get("url") for n in one_links]
 
     # A leaf subsection's span scopes to its own content only.
-    two_links = doc.collect(contains=section_two.span, kinds={NodeKind.link}, recursive=True)
+    two_links = doc.collect(within=section_two.span, kinds={NodeKind.link})
     two_urls = [n.attrs.get("url") for n in two_links]
     assert "https://two.example.com" in two_urls
     assert "https://one.example.com" not in two_urls
@@ -350,6 +350,25 @@ def test_overlaps_matches_only_intersecting_spans():
     # A region wholly inside the heading does not reach the paragraph.
     heading_only = doc.collect(overlaps=(0, 3), layer={Layer.markdown}, recursive=True)
     assert all(n.kind != NodeKind.paragraph for n in heading_only)
+
+
+def test_conflicting_alias_pairs_raise():
+    """Passing a deprecated alias together with its modern name is a ValueError, not
+    silent precedence."""
+    doc = TextDoc.from_text(_RICH_DOC)
+    rid = doc.node_table().roots[0]
+    try:
+        doc.collect(scope=rid, subtree_of=rid)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError for scope + subtree_of")
+    try:
+        doc.collect(contains=(0, 5), within=(0, 5))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError for contains + within")
 
 
 def test_textdoc_base_blocks_matches_free_function():

--- a/tests/docs/test_collect.py
+++ b/tests/docs/test_collect.py
@@ -87,16 +87,32 @@ def test_non_recursive_returns_only_roots():
         assert n.id in root_ids
 
 
-def test_links_via_inline_flag():
-    """Links are inline nodes; they require `inline=True` to appear."""
+def test_explicit_link_kind_implies_inline():
+    """An explicit inline `kinds` selection returns inline nodes without `inline=True`."""
     _, table = _doc_and_table()
-    # Without inline flag, no links returned.
-    no_inline = collect(table, kinds={NodeKind.link}, recursive=True, inline=False)
-    assert len(no_inline) == 0
+    # Explicit kinds={link} works on its own (no inline flag needed).
+    links = collect(table, kinds={NodeKind.link}, recursive=True)
+    assert len(links) >= 2
 
-    # With inline flag, links are returned.
+    # Passing inline=True as well changes nothing.
     with_inline = collect(table, kinds={NodeKind.link}, recursive=True, inline=True)
-    assert len(with_inline) >= 2
+    assert len(with_inline) == len(links)
+
+
+def test_inline_excluded_by_default_without_explicit_kind():
+    """A query that does not name an inline kind still excludes inline nodes by default."""
+    _, table = _doc_and_table()
+    all_default = collect(table, recursive=True)
+    assert all(n.kind not in {NodeKind.link, NodeKind.code_span} for n in all_default)
+    # Opting in with inline=True surfaces them.
+    assert any(n.kind == NodeKind.link for n in collect(table, recursive=True, inline=True))
+
+
+def test_collect_single_link_minimal_doc():
+    """The common case from the review: kinds={link} on a tiny doc returns the one link."""
+    doc = TextDoc.from_text("[x](https://example.com)")
+    links = doc.collect(kinds={NodeKind.link}, recursive=True)
+    assert len(links) == 1
 
 
 def test_scope_restricts_to_subtree():
@@ -242,12 +258,10 @@ def test_textdoc_collect_with_scope():
 
 
 def test_code_spans_inline():
-    """Code spans are inline nodes and require inline=True."""
+    """Code spans are inline; an explicit kinds={code_span} returns them without inline=True."""
     doc = TextDoc.from_text(_RICH_DOC)
-    spans_no = doc.collect(kinds={NodeKind.code_span}, recursive=True, inline=False)
-    assert len(spans_no) == 0
-    spans_yes = doc.collect(kinds={NodeKind.code_span}, recursive=True, inline=True)
-    assert len(spans_yes) >= 1
+    spans = doc.collect(kinds={NodeKind.code_span}, recursive=True)
+    assert len(spans) >= 1
 
 
 def test_collect_layer_filters_cross_layer_duplicates():
@@ -275,6 +289,22 @@ def test_collect_layer_does_not_silently_drop_sections():
     td = TextDoc.from_text("# Title\n\nBody paragraph.\n")
     assert td.collect(kinds={NodeKind.section}, recursive=True)  # default: found
     assert td.collect(kinds={NodeKind.section}, recursive=True, layer={Layer.markdown}) == []
+
+
+def test_doc_collect_links_in_section_matches_spec_example():
+    """The spec §9 recipe: doc.collect(contains=section.span, kinds={link}, recursive=True)."""
+    doc = TextDoc.from_text(_RICH_DOC)
+    section_one = doc.sections()[0]
+    section_two = section_one.children[0]
+
+    one_links = doc.collect(contains=section_one.span, kinds={NodeKind.link}, recursive=True)
+    assert "https://one.example.com" in [n.attrs.get("url") for n in one_links]
+
+    # A leaf subsection's span scopes to its own content only.
+    two_links = doc.collect(contains=section_two.span, kinds={NodeKind.link}, recursive=True)
+    two_urls = [n.attrs.get("url") for n in two_links]
+    assert "https://two.example.com" in two_urls
+    assert "https://one.example.com" not in two_urls
 
 
 def test_textdoc_base_blocks_matches_free_function():

--- a/tests/docs/test_interval_index.py
+++ b/tests/docs/test_interval_index.py
@@ -58,6 +58,50 @@ def test_innermost_kind_filter_selects_section_and_sentence():
     assert table.node(sent_id).kind == NodeKind.sentence
 
 
+def test_innermost_matches_bruteforce_minwidth_scan():
+    """Over a richly nested document, `innermost` returns a narrowest-containing node for
+    every offset and layer/kind, matching a brute-force min-width scan (pins the
+    same-layer-nesting assumption the index relies on)."""
+    rich = (
+        "# Top\n\n"
+        "Intro with a [link](https://example.com) here.\n\n"
+        "> Quote with `code` inside.\n>\n> | a | b |\n> | - | - |\n> | 1 | 2 |\n\n"
+        "## Sub\n\n"
+        "- item one\n- item two with [two](https://example.com/2)\n  - nested\n\n"
+        "Final sentence."
+    )
+    table = build_node_table(TextDoc.from_text(rich))
+    index = IntervalIndex.from_nodes(table.nodes)
+
+    def min_containing_width(offset: int, layer: Layer, kind: NodeKind | None) -> int | None:
+        widths = [
+            n.source_span[1] - n.source_span[0]
+            for n in table.nodes.values()
+            if n.layer == layer
+            and n.source_span is not None
+            and (kind is None or n.kind == kind)
+            and n.source_span[0] <= offset < n.source_span[1]
+        ]
+        return min(widths) if widths else None
+
+    cases = [
+        (Layer.markdown, None),
+        (Layer.document, NodeKind.section),
+        (Layer.textual, NodeKind.sentence),
+    ]
+    for offset in range(len(rich) + 1):
+        for layer, kind in cases:
+            got = index.innermost(offset, layer, kind)
+            expected_width = min_containing_width(offset, layer, kind)
+            if expected_width is None:
+                assert got is None, (offset, layer, kind)
+            else:
+                assert got is not None, (offset, layer, kind)
+                span = table.node(got).source_span
+                assert span is not None
+                assert span[1] - span[0] == expected_width, (offset, layer, kind)
+
+
 def test_innermost_returns_none_outside_any_span():
     table = build_node_table(TextDoc.from_text(_DOC))
     index = IntervalIndex.from_nodes(table.nodes)

--- a/tests/docs/test_interval_index.py
+++ b/tests/docs/test_interval_index.py
@@ -1,0 +1,67 @@
+"""
+Tests for `IntervalIndex`: innermost-containing lookups over nested node spans,
+including kind filtering and offsets that fall in gaps.
+"""
+
+from __future__ import annotations
+
+from textwrap import dedent
+
+from chopdiff.docs.interval_index import IntervalIndex
+from chopdiff.docs.node import Layer, NodeKind
+from chopdiff.docs.node_table import build_node_table
+from chopdiff.docs.text_doc import TextDoc
+
+_DOC = dedent("""
+    # Top
+
+    Intro paragraph with a [link](https://example.com) inside.
+
+    ## Sub
+
+    Another paragraph here.
+""").strip()
+
+
+def test_innermost_picks_narrowest_nested_span():
+    """For nested markdown spans, innermost returns the deepest (narrowest) container,
+    and the kind filter selects a specific enclosing kind."""
+    table = build_node_table(TextDoc.from_text(_DOC))
+    index = IntervalIndex.from_nodes(table.nodes)
+    link_off = _DOC.index("https://example.com")
+
+    # Unfiltered: the narrowest markdown node containing the offset is the link itself.
+    narrowest = index.innermost(link_off, Layer.markdown)
+    assert narrowest is not None
+    assert table.node(narrowest).kind == NodeKind.link
+
+    # Filtered to paragraphs: the enclosing paragraph block.
+    para_id = index.innermost(link_off, Layer.markdown, kind=NodeKind.paragraph)
+    assert para_id is not None
+    para = table.node(para_id)
+    assert para.kind == NodeKind.paragraph
+    assert para.source_span is not None
+    assert para.source_span[0] <= link_off < para.source_span[1]
+
+
+def test_innermost_kind_filter_selects_section_and_sentence():
+    table = build_node_table(TextDoc.from_text(_DOC))
+    index = IntervalIndex.from_nodes(table.nodes)
+    link_off = _DOC.index("https://example.com")
+
+    section_id = index.innermost(link_off, Layer.document, kind=NodeKind.section)
+    assert section_id is not None
+    assert table.node(section_id).attrs.get("title") == "Top"
+
+    sent_id = index.innermost(link_off, Layer.textual, kind=NodeKind.sentence)
+    assert sent_id is not None
+    assert table.node(sent_id).kind == NodeKind.sentence
+
+
+def test_innermost_returns_none_outside_any_span():
+    table = build_node_table(TextDoc.from_text(_DOC))
+    index = IntervalIndex.from_nodes(table.nodes)
+    # An offset past the end of the document is contained by nothing.
+    assert index.innermost(len(_DOC) + 100, Layer.markdown) is None
+    # A layer with no indexed nodes yields None.
+    assert index.innermost(0, Layer.synthetic) is None

--- a/tests/docs/test_node.py
+++ b/tests/docs/test_node.py
@@ -1,0 +1,53 @@
+"""
+Tests for the pure node-model types: `NodeKind`/`BlockType` parity, inline-kind
+membership, and the `LAYER_NESTING` invariant.
+"""
+
+from __future__ import annotations
+
+from chopdiff.docs.block_types import BlockType
+from chopdiff.docs.node import LAYER_NESTING, Layer, NestingGuarantee, Node, NodeKind
+
+
+def test_block_kinds_match_block_type_values():
+    block_type_values = {bt.value for bt in BlockType}
+    block_node_kinds = {
+        nk.value
+        for nk in NodeKind
+        if nk
+        not in (
+            NodeKind.link,
+            NodeKind.code_span,
+            NodeKind.image,
+            NodeKind.inline_html,
+            NodeKind.section,
+            NodeKind.sentence,
+        )
+    }
+    assert block_node_kinds == block_type_values
+
+
+def test_inline_kinds_exist():
+    inline_kinds = {NodeKind.link, NodeKind.code_span, NodeKind.image, NodeKind.inline_html}
+    assert all(k in NodeKind for k in inline_kinds)
+    assert NodeKind.section not in inline_kinds
+    assert NodeKind.sentence not in inline_kinds
+
+
+def test_layer_nesting_covers_every_layer():
+    for layer in Layer:
+        assert layer in LAYER_NESTING, f"LAYER_NESTING missing {layer}"
+
+
+def test_nesting_guarantee_values():
+    assert LAYER_NESTING[Layer.textual] == NestingGuarantee.ordered_list
+    assert LAYER_NESTING[Layer.markdown] == NestingGuarantee.tree
+    assert LAYER_NESTING[Layer.document] == NestingGuarantee.tree
+    assert LAYER_NESTING[Layer.synthetic] == NestingGuarantee.tree
+
+
+def test_node_defaults():
+    n = Node(id="n_0001", kind=NodeKind.paragraph, layer=Layer.markdown, parent=None)
+    assert n.children == []
+    assert n.source_span is None
+    assert n.attrs == {}

--- a/tests/docs/test_sections.py
+++ b/tests/docs/test_sections.py
@@ -134,3 +134,23 @@ def test_section_links_include_reference_links():
     section = TextDoc.from_text(text).sections()[0]
     urls = {lk.url for lk in section.links()}
     assert "https://docs.example" in urls
+
+
+def test_heading_inside_code_fence_is_not_a_section():
+    """A '#'-prefixed line inside a fenced code block (which blank-line paragraph
+    splitting can isolate) must not become a section; only the real heading counts."""
+    md = dedent(
+        """
+        # Real
+
+        ```
+        text
+
+        # Not a heading
+        ```
+
+        After.
+        """
+    ).strip()
+    doc = TextDoc.from_text(md)
+    assert [title for _, title, _ in doc.toc()] == ["Real"]

--- a/tests/docs/test_span_ref.py
+++ b/tests/docs/test_span_ref.py
@@ -5,11 +5,12 @@ after edits, persisted form resolution, and fast-path behavior.
 
 from __future__ import annotations
 
+import dataclasses
 from textwrap import dedent
 
 from chopdiff.docs.node import Layer, NodeKind
 from chopdiff.docs.node_table import build_node_table
-from chopdiff.docs.span_ref import SpanRef, resolve
+from chopdiff.docs.span_ref import SpanRef, resolve, resolve_and_update
 from chopdiff.docs.text_doc import TextDoc
 
 _DOC_TEXT = dedent("""
@@ -154,11 +155,41 @@ def test_resolve_returns_none_for_missing_text():
 
 
 def test_to_text_fragment():
-    """to_text_fragment produces a Chrome-style text fragment."""
+    """to_text_fragment produces a Chrome-style text fragment with encoded components."""
     ref = SpanRef(exact="sample link", prefix="A [", suffix="]")
     frag = ref.to_text_fragment()
-    assert frag.startswith("#:~:text=")
-    assert "sample link" in frag
+    assert frag == "#:~:text=A%20%5B-,sample%20link,-%5D"
+
+
+def test_to_text_fragment_percent_encoded():
+    """Spaces, delimiters, and non-ASCII in the exact text are percent-encoded."""
+    ref = SpanRef(exact="a b # c, π")
+    assert ref.to_text_fragment() == "#:~:text=a%20b%20%23%20c%2C%20%CF%80"
+
+
+def test_resolve_does_not_mutate():
+    """resolve() is pure: it never writes offsets back into the SpanRef."""
+    ref = SpanRef(exact="target")
+    before = dataclasses.replace(ref)
+    result = resolve(ref, "before target after")
+    assert result is not None
+    assert ref == before
+
+
+def test_resolve_and_update_writes_offsets():
+    """resolve_and_update() writes the recomputed offsets back for fast-path reuse."""
+    ref = SpanRef(exact="target")
+    result = resolve_and_update(ref, "before target after")
+    assert result is not None
+    assert (ref.start, ref.end) == result
+
+
+def test_to_persisted_can_keep_position_hint():
+    """to_persisted keeps offsets only when explicitly asked."""
+    ref = SpanRef(exact="x", start=3, end=4)
+    assert ref.to_persisted().start is None
+    kept = ref.to_persisted(include_position_hint=True)
+    assert (kept.start, kept.end) == (3, 4)
 
 
 def test_resolve_survives_reparse():

--- a/tests/docs/test_text_doc.py
+++ b/tests/docs/test_text_doc.py
@@ -437,3 +437,19 @@ def test_is_footnote_def_detection():
     assert not doc.paragraphs[0].is_footnote_def()
     assert not doc.paragraphs[1].is_footnote_def()
     assert doc.paragraphs[2].is_footnote_def()
+
+
+def test_set_sent_preserves_original_source_span():
+    """set_sent keeps the replaced sentence's span pointing at the original source slice,
+    even when the replacement text has a different length (the documented contract)."""
+    doc = TextDoc.from_text("Hello world.")
+    idx = SentIndex(0, 0)
+    before = doc.get_sent(idx).span
+
+    doc.set_sent(idx, "Hello much longer replacement world.")
+    after_sent = doc.get_sent(idx)
+
+    # Editable text reflects the edit; the source span is unchanged.
+    assert after_sent.text == "Hello much longer replacement world."
+    assert after_sent.span == before
+    assert doc.source_text[before[0] : before[1]] == "Hello world."

--- a/tests/golden/expected/malformed/docgraph.yaml
+++ b/tests/golden/expected/malformed/docgraph.yaml
@@ -27,28 +27,15 @@ nodes:
 - id: n0004
   kind: section
   layer: document
-  children:
-  - n0005
   source_span:
     start: 0
     end: 234
   attrs:
     level: 1
     title: Malformed
-- id: n0005
-  kind: section
-  layer: document
-  parent: n0004
-  source_span:
-    start: 87
-    end: 234
-  attrs:
-    level: 2
-    title: A heading that is actually inside the open fence?
 views:
   toc:
   - n0004
-  - n0005
   blocks:
   - n0001
   - n0002

--- a/tests/golden/expected/malformed/report.yaml
+++ b/tests/golden/expected/malformed/report.yaml
@@ -34,10 +34,6 @@ sections:
   title: Malformed
   span: 0:234
   words: 43
-- level: 2
-  title: A heading that is actually inside the open fence?
-  span: 87:234
-  words: 30
 node_table:
 - id: n0001
   layer: markdown
@@ -61,76 +57,68 @@ node_table:
     level: 1
     title: Malformed
 - id: n0005
-  layer: document
-  kind: section
-  span: 87:234
-  parent: n0004
-  attrs:
-    level: 2
-    title: A heading that is actually inside the open fence?
+  layer: textual
+  kind: paragraph
+  span: 0:11
 - id: n0006
   layer: textual
-  kind: paragraph
-  span: 0:11
-- id: n0007
-  layer: textual
   kind: sentence
   span: 0:11
-  parent: n0006
+  parent: n0005
   attrs:
     text: '# Malformed'
+- id: n0007
+  layer: textual
+  kind: paragraph
+  span: 13:52
 - id: n0008
   layer: textual
-  kind: paragraph
-  span: 13:52
-- id: n0009
-  layer: textual
   kind: sentence
   span: 13:52
-  parent: n0008
+  parent: n0007
   attrs:
     text: 'A paragraph then an unterminated fence:'
+- id: n0009
+  layer: textual
+  kind: paragraph
+  span: 54:85
 - id: n0010
   layer: textual
-  kind: paragraph
-  span: 54:85
-- id: n0011
-  layer: textual
   kind: sentence
   span: 54:85
-  parent: n0010
+  parent: n0009
   attrs:
     text: '```python def f(): return 1'
+- id: n0011
+  layer: textual
+  kind: paragraph
+  span: 87:139
 - id: n0012
   layer: textual
-  kind: paragraph
-  span: 87:139
-- id: n0013
-  layer: textual
   kind: sentence
   span: 87:139
-  parent: n0012
+  parent: n0011
   attrs:
     text: '## A heading that is actually inside the open fence?'
+- id: n0013
+  layer: textual
+  kind: paragraph
+  span: 141:185
 - id: n0014
   layer: textual
-  kind: paragraph
-  span: 141:185
-- id: n0015
-  layer: textual
   kind: sentence
   span: 141:185
-  parent: n0014
+  parent: n0013
   attrs:
     text: '| ragged | table | - | | one | two | three |'
-- id: n0016
+- id: n0015
   layer: textual
   kind: paragraph
   span: 187:234
-- id: n0017
+- id: n0016
   layer: textual
   kind: sentence
   span: 187:234
-  parent: n0016
+  parent: n0015
   attrs:
     text: '- item with [an unclosed link](http://x.example'


### PR DESCRIPTION
## Summary

Addresses the v0.3.1 senior engineering review of the TextDoc/DocGraph document model and follows it with the performance work the review and profiling pointed to. The architecture (one immutable source string + Unicode code-point offset space as canonical substrate; layered projections) is endorsed and preserved; this PR tightens correctness, query semantics, section construction, and parse performance, and makes read-time caching explicitly thread-safe and documented.

**Scope note:** the branch is cut above `main` and rolls up earlier doc-model phases already reviewed in #12/#14/#15. **The new work in this PR is the 5 commits since the review baseline** (`ae6b6a2`), touching 20 files (+846/−300). Tracked under tbd epic `chopdiff-cea0`.

## Changes

**Tier A — correctness & docs (`71f7ce8`)**
- `collect(kinds={NodeKind.link})` no longer silently returns nothing — an explicit inline `kinds` now implies inline inclusion (was filtered out unless `inline=True`).
- `SpanRef`: percent-encode `to_text_fragment()`; make `resolve()` pure and add explicit `resolve_and_update()`; make `to_persisted()` offset retention an explicit `include_position_hint` flag.
- `set_sent()` preserves the replaced sentence's `original_text` so its `span` keeps describing the original source slice (contract decision: preserve, not invalidate).
- Spec/migration examples corrected to the implemented API (`doc.collect()` / `doc.graph()`), not the non-existent `dg.collect()`/`dg.section()`.
- "node table is canonical" → "projection over the canonical source/offset substrate" (`node.py`, `node_table.py`, CHANGELOG). Cleanups: removed dead `included_ids`, unified DocGraph parent-inclusion predicate, moved `node.py` tests to `tests/docs/test_node.py`, `deque` in subtree walk, typo.

**Tier B — interval queries & structural sections (`eacd896`, `15f562e`)**
- **B1 `IntervalIndex`**: per-layer, start-sorted span index; node-table inline attribution goes through it instead of scanning the whole table per inline element, making `build_node_table` linear instead of `O(inline × nodes)`.
- **B2 query relations**: `collect()` gains `subtree_of` (tree) and `within`/`overlaps` (cross-layer interval, each accepting a node id or `(start,end)` span); `scope`/`contains` kept as deprecated aliases. `within=section_id` now gathers everything in a section without `recursive=True`.
- **B3 structural sections**: `sections()`/`toc()` derive headings from top-level structural `heading` blocks (matched to paragraphs by offset), not the blank-line paragraph view. Fixes phantom sections from `#`-lines inside fenced code blocks. **Behavior change:** the `malformed` golden loses one phantom level-2 section (regenerated).

**Performance — parse once, thread-safe caching (`89af8f6`, `320181e`)**
- `blocks()`, `links()`, and `base_blocks()` now derive from one cached marko parse of `source_text` instead of each re-parsing the whole document. `node_table()` build roughly halved (measured **381 ms → 180 ms** on a 66 KB doc; full-doc parses 2 → 1), scaling stays linear.
- Per-heading parsing consolidated: `block_type` + `heading_level` + `heading_title` share one cached `_block_info` (heading-string parses 3 → 1 per heading).
- Read-time caching is thread-safe: a `_memoized_derivation` decorator fills each document-level cache under a per-instance reentrant lock; reads are otherwise side-effect-free and deterministic. The `TextDoc` docstring documents the read-only/thread-safety contract, including that per-element `cached_property` values (`Paragraph.block_type`) are idempotent and deterministic though not lock-guarded.

## Test Plan

Validation performed (all green on the final state):
- [x] **Lint/type check** — `make lint` (ruff + basedpyright): 0 errors, 0 warnings.
- [x] **Full suite** — `make test`: **310 passed** (8 doc-model test files updated/added this session).
- [x] **Golden corpus** — `tests/golden/` (7 documents × report.yaml / docgraph.yaml / reassembled.md) all match; the only intentional change (`malformed` losing a phantom section) was reviewed in the diff and regenerated. `test_model_invariants` (independent of the golden text) still passes: base-block cover, SpanRef round-trips, node-id uniqueness, parent/child resolution, reassemble idempotence.
- [x] **Targeted unit tests added for each change:**
  - A1: `collect(kinds={link})` returns links without `inline=True`; inline still excluded by default otherwise.
  - A3: percent-encoded text fragment (incl. the review's exact case); `resolve()` non-mutation; `resolve_and_update()`; `to_persisted` hint flag.
  - A4: `set_sent` preserves the original source span across a length-changing edit.
  - B1: `IntervalIndex.innermost` narrowest-wins, kind filter, out-of-range → None.
  - B2: `within=section_id` cross-layer without recursive; `overlaps` intersect-only; `scope`/`contains` aliases.
  - B3: heading inside a fenced code block is not a section.
  - Caching/threads: shared-parse equivalence vs independent parses; read-order independence; cache identity stability; **concurrency test — 32 concurrent `node_table()` calls across 8 threads parse exactly once and return one shared table.**
- [x] **Performance verified by measurement** (not just asserted): linear per-stage scaling across 200→1600 paragraphs; `node_table` build 381 → 180 ms after parse-sharing; full-doc parses 2 → 1; heading parses 120 → 40.

Edge cases covered: heading-in-code-fence, headings nested in blockquotes/list items (not sections), setext headings, HTML headers (already non-sections — unchanged), reference links with no recoverable span, cross-layer duplicate spans via `layer=`.

## Validation gaps / recommended follow-ups

- **Concurrency** is tested under CPython (GIL). The locking is written to be correct without relying on the GIL, but it has not been exercised under free-threaded (3.13t) builds — worth a run if no-GIL becomes a target.
- **Perf budgets are measured, not gated.** No CI performance regression test exists; the numbers here are from local microbenchmarks. A lightweight budget test (e.g. parse-count assertions like the concurrency test uses) could lock in "one full parse per build."
- **Secondary parse cost remains:** 40 small heading parses per build and `base_blocks()` sharing only when called via `TextDoc`. Acceptable; noted.
- **Not in this PR (open beads, deliberately deferred):** Tier C — immutable `DocumentSnapshot`/freezing (`chopdiff-x956`), query-object public story (`chopdiff-3gzp`), DocGraph schema hardening / JSONValue / node-id-order pinning (`chopdiff-6923`), `text_doc.py` split (`chopdiff-ub1q`), `SpanRef` selector family + fuzzy anchoring (`chopdiff-tidk`, fuzzy deferred per maintainer), synthetic-overlap semantics + edge/perf corpus (`chopdiff-yj7o`). These need the two open product decisions (snapshot public surface; query-object home).
- **Manual review suggested for:** the `malformed` golden diff (intentional phantom-section removal) and the `TextDoc` read-time-caching contract wording.

## Related Beads

Epic `chopdiff-cea0`. Closed this session: `chopdiff-b71t` (A1), `chopdiff-5jg4` (A2), `chopdiff-nmof` (A3), `chopdiff-iiwp` (A4), `chopdiff-awb9` (A5), `chopdiff-s1yj` (A6), `chopdiff-f7lc` (B1), `chopdiff-uo2s` (B2), `chopdiff-0ahr` (B3), `chopdiff-lu2b` (parse-once perf). Open (Tier C): `chopdiff-x956`, `chopdiff-3gzp`, `chopdiff-6923`, `chopdiff-ub1q`, `chopdiff-tidk`, `chopdiff-yj7o`.

https://claude.ai/code/session_01GdbMNBJzVqpAScLqEPhQpv