### PR TITLE
DocGraph node model + v0.3.1 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to chopdiff are documented here.
 This project uses [semantic versioning](https://semver.org/); while pre-1.0, breaking
 changes bump the **minor** version (see `docs/publishing.md`).
 
-## v0.4.0
+## v0.3.1
+
+Versioned as a patch despite the breaking changes below: they touch only the block-type
+and sentence-splitting surface introduced in v0.3.0, which is very new and not yet relied
+upon. (The pre-1.0 policy otherwise bumps the minor version for breaking changes.)
 
 Makes `TextDoc` block-aware end to end and adds the DocGraph node model on top of it.
 The block-aware layer gives an exact-span structural block tree, a section hierarchy
@@ -172,7 +176,7 @@ no Markdown block-detection regex of its own.
 
 ### Full Changelog
 
-https://github.com/jlevy/chopdiff/compare/v0.3.0...v0.4.0
+https://github.com/jlevy/chopdiff/compare/v0.3.0...v0.3.1
 
 ## v0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,67 @@ All notable changes to chopdiff are documented here.
 This project uses [semantic versioning](https://semver.org/); while pre-1.0, breaking
 changes bump the **minor** version (see `docs/publishing.md`).
 
-## Unreleased
+## v0.4.0
 
-Adds the DocGraph node model and its supporting infrastructure: a recursive node table
-with layers, the `base_blocks()` sequential partition, `collect()` query primitive,
-`SpanRef` span-reference type, and the `DocGraph` Pydantic projection (schema
-“DocGraph/v0.1”).
+Makes `TextDoc` block-aware end to end and adds the DocGraph node model on top of it.
+The block-aware layer gives an exact-span structural block tree, a section hierarchy
+with rolled-up stats, inline-link rollups, and link-aware sentence spans. The DocGraph
+layer then adds a recursive, layer-tagged node table, the `base_blocks()` sequential
+partition, the `collect()` query primitive, the `SpanRef` span-reference type, and the
+`DocGraph` Pydantic projection (schema “DocGraph/v0.1”).
+The source text and its offset space are canonical; every view (the structural block
+tree, sections, block-type slices, tallies, and the node table) is a projection over
+that substrate: no stored counts.
+Block boundaries and spans now come straight from flowmark’s parser, so chopdiff carries
+no Markdown block-detection regex of its own.
+
+### Breaking Changes
+
+- **`BlockType.list` is now bullet-only; ordered lists are `BlockType.ordered_list`.**
+  Ordered-ness is carried from marko’s `List.ordered`. Callers that matched
+  `BlockType.list` to cover *both* list kinds now miss ordered lists; match
+  `{BlockType.list, BlockType.ordered_list}` for either.
+- **Default sentence splitting is now span-aware.** `TextDoc.from_text()` with the
+  default splitter now routes through `flowmark.atomic_spans.split_sentences_with_spans`
+  instead of calling `split_sentences_regex` directly, so sentences never bisect a link,
+  code span, or autolink.
+  Sentence boundaries can therefore differ from v0.3.0 for text containing those
+  constructs. `default_sentence_splitter` is unchanged and passing an explicit splitter
+  preserves the previous behavior.
 
 ### New Features
 
+- **Opt-in structural block tree with exact spans.** `TextDoc.blocks()` returns a
+  `Block(type, span, children, tight)` tree whose boundaries and `[start, end)` spans
+  come directly from flowmark’s parser (marko’s own source positions), so a fenced code
+  block stays whole through internal blank lines and a list always decomposes into
+  `list_item`s with nested sublists.
+  The tree is **density-invariant**: tight and loose spacing of the same list produce
+  identical block/item counts; `Block.tight` records the CommonMark spacing.
+- **Per-section structure and tallies.** `Section.blocks()` scopes the structural tree
+  to a section’s own content (document-absolute spans), and
+  `Section.block_type_counts()` / `TextDoc.block_type_counts()` give derived
+  `Counter[BlockType]` tallies over the live tree (no stored counts).
+  `Section.content` holds the section’s own paragraphs (renamed from `Section.blocks`,
+  which is now the structural method).
+- **Sections, TOC, and rolled-up size stats.** `TextDoc.sections()` returns a tree of
+  `Section`s over the heading hierarchy; `TextDoc.toc()` returns a flat
+  `(level, title, span)` list.
+  `Section.size(unit, subtree=True|False)`, `Section.size_summary()`, and
+  `TextDoc.section_size_tree(units=…)` roll up sizes per section in any `TextUnit`.
+- **Exact `[start, end)` spans on paragraphs and sentences.** Every `Paragraph` and
+  `Sentence` exposes a document-relative `span`; `TextDoc.source_text` is retained so
+  each unit’s `original_text` round-trips into the source.
+  `TextDoc.block_at_offset(o)` and `sentence_at_offset(o)` invert spans.
+- **Inline-link rollups and link-aware sentence spans.** `Link(text, url, title, span)`
+  via `Paragraph.links()`, `Section.links()`, and `TextDoc.links()`—identity from
+  flowmark’s `extract_links` (reference links resolve across the whole document), spans
+  recovered from `iter_atomic_spans`. The default sentence splitter is now
+  `flowmark.atomic_spans.split_sentences_with_spans`, so sentence spans are exact for
+  all content and never bisect a link, code span, or autolink.
+- **More block types:** `BlockType` gains `ordered_list`, `list_item`, and
+  `thematic_break`.
+- **New public exports:** `Block`, `Link`, `Section`.
 - **Recursive node table with layers.** The canonical node table fully populates
   container children (blockquotes, list items) and tags each node with its parse `layer`
   (textual, markdown, document, synthetic).
@@ -74,6 +126,16 @@ with layers, the `base_blocks()` sequential partition, `collect()` query primiti
   same value; reads are otherwise side-effect-free and deterministic. See the `TextDoc`
   read-time-caching contract.
 
+### Internal
+
+- **Dropped chopdiff’s regex block scanner.** `TextDoc.blocks()` and
+  `Paragraph.block_type` now walk flowmark’s annotated parse tree and map marko classes
+  to `BlockType` through a single table; the per-line regex scanner, `classify_block`,
+  and the cached `markdown_parser` singleton are gone (net negative code).
+  Because chopdiff no longer makes block-boundary decisions, two earlier bugs are fixed
+  by construction: reference links resolve across block boundaries, and adjacent blocks
+  with no blank line between them split correctly.
+
 ### Documentation
 
 - **Grounded design principles.** `docs/textdoc-spec.md` now leads with an explicit,
@@ -90,6 +152,10 @@ with layers, the `base_blocks()` sequential partition, `collect()` query primiti
 - New runtime dependency: `frontmatter-format>=0.3.0` (first-party; brings
   `ruamel-yaml`). Used for clean deterministic YAML (`DocGraph.to_yaml`, the debug
   dumper) and the Markdown-with-frontmatter golden-test corpus.
+- Requires `flowmark>=0.7.1` for the authoritative block spans
+  ([jlevy/flowmark#52](https://github.com/jlevy/flowmark/pull/52)); recorded as a
+  reviewed first-party cool-off exception in `SUPPLY-CHAIN-SECURITY.md`. No new
+  transitive dependencies over 0.7.0.
 
 ### Compatibility
 
@@ -98,87 +164,11 @@ with layers, the `base_blocks()` sequential partition, `collect()` query primiti
   `Layer`, `Detail`, `Views`, `build_doc_graph`, …) without removing or renaming any
   existing export. `Section.block_type_counts()` / `TextDoc.block_type_counts()` are
   retained; `collect()` is the preferred general query, not a replacement.
-- **Net release vs. v0.3.0.** Taken together with v0.4.0 (below), the upcoming release
-  removes no public symbol present in v0.3.0; every new capability is reached through
-  new methods, types, and exports.
-  The only behavior changes an existing caller can observe are the two noted under
-  v0.4.0: `BlockType.list` is now bullet-only, and default sentence splitting is now
-  span-aware (boundaries may differ; see below).
-
-## v0.4.0
-
-Makes `TextDoc` block-aware end to end: an exact-span structural block tree, a section
-hierarchy with rolled-up stats, inline-link rollups, and link-aware sentence spans.
-The source text and its offset space are canonical; every view (the structural block
-tree, sections, block-type slices, tallies) is a projection over that substrate: no
-stored counts.
-Block boundaries and spans now come straight from flowmark’s parser, so chopdiff carries
-no Markdown block-detection regex of its own.
-
-### Breaking Changes
-
-- **`BlockType.list` is now bullet-only; ordered lists are `BlockType.ordered_list`.**
-  Ordered-ness is carried from marko’s `List.ordered`. Callers that matched
-  `BlockType.list` to cover *both* list kinds now miss ordered lists; match
-  `{BlockType.list, BlockType.ordered_list}` for either.
-- **Default sentence splitting is now span-aware.** `TextDoc.from_text()` with the
-  default splitter now routes through `flowmark.atomic_spans.split_sentences_with_spans`
-  instead of calling `split_sentences_regex` directly, so sentences never bisect a link,
-  code span, or autolink.
-  Sentence boundaries can therefore differ from v0.3.0 for text containing those
-  constructs. `default_sentence_splitter` is unchanged and passing an explicit splitter
-  preserves the previous behavior.
-
-### New Features
-
-- **Opt-in structural block tree with exact spans.** `TextDoc.blocks()` returns a
-  `Block(type, span, children, tight)` tree whose boundaries and `[start, end)` spans
-  come directly from flowmark’s parser (marko’s own source positions), so a fenced code
-  block stays whole through internal blank lines and a list always decomposes into
-  `list_item`s with nested sublists.
-  The tree is **density-invariant**: tight and loose spacing of the same list produce
-  identical block/item counts; `Block.tight` records the CommonMark spacing.
-- **Per-section structure and tallies.** `Section.blocks()` scopes the structural tree
-  to a section’s own content (document-absolute spans), and
-  `Section.block_type_counts()` / `TextDoc.block_type_counts()` give derived
-  `Counter[BlockType]` tallies over the live tree (no stored counts).
-  `Section.content` holds the section’s own paragraphs (renamed from `Section.blocks`,
-  which is now the structural method).
-- **Sections, TOC, and rolled-up size stats.** `TextDoc.sections()` returns a tree of
-  `Section`s over the heading hierarchy; `TextDoc.toc()` returns a flat
-  `(level, title, span)` list.
-  `Section.size(unit, subtree=True|False)`, `Section.size_summary()`, and
-  `TextDoc.section_size_tree(units=…)` roll up sizes per section in any `TextUnit`.
-- **Exact `[start, end)` spans on paragraphs and sentences.** Every `Paragraph` and
-  `Sentence` exposes a document-relative `span`; `TextDoc.source_text` is retained so
-  each unit’s `original_text` round-trips into the source.
-  `TextDoc.block_at_offset(o)` and `sentence_at_offset(o)` invert spans.
-- **Inline-link rollups and link-aware sentence spans.** `Link(text, url, title, span)`
-  via `Paragraph.links()`, `Section.links()`, and `TextDoc.links()`—identity from
-  flowmark’s `extract_links` (reference links resolve across the whole document), spans
-  recovered from `iter_atomic_spans`. The default sentence splitter is now
-  `flowmark.atomic_spans.split_sentences_with_spans`, so sentence spans are exact for
-  all content and never bisect a link, code span, or autolink.
-- **More block types:** `BlockType` gains `ordered_list`, `list_item`, and
-  `thematic_break`.
-- **New public exports:** `Block`, `Link`, `Section`.
-
-### Internal
-
-- **Dropped chopdiff’s regex block scanner.** `TextDoc.blocks()` and
-  `Paragraph.block_type` now walk flowmark’s annotated parse tree and map marko classes
-  to `BlockType` through a single table; the per-line regex scanner, `classify_block`,
-  and the cached `markdown_parser` singleton are gone (net negative code).
-  Because chopdiff no longer makes block-boundary decisions, two earlier bugs are fixed
-  by construction: reference links resolve across block boundaries, and adjacent blocks
-  with no blank line between them split correctly.
-
-### Dependencies
-
-- Requires `flowmark>=0.7.1` for the authoritative block spans
-  ([jlevy/flowmark#52](https://github.com/jlevy/flowmark/pull/52)); recorded as a
-  reviewed first-party cool-off exception in `SUPPLY-CHAIN-SECURITY.md`. No new
-  transitive dependencies over 0.7.0.
+- **Net release vs. v0.3.0.** This release removes no public symbol present in v0.3.0;
+  every new capability is reached through new methods, types, and exports.
+  The only behavior changes an existing caller can observe are the two listed under
+  Breaking Changes above: `BlockType.list` is now bullet-only, and default sentence
+  splitting is now span-aware (boundaries may differ).
 
 ### Full Changelog
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 # chopdiff: Open Work
 
 A concise index of planned work, the specs that describe it, and the beads that track
-it. Status as of 2026-06-02 (v0.4.0 — block-aware model + DocGraph Phase 1 — code-complete
+it. Status as of 2026-06-02 (v0.3.1 — block-aware model + DocGraph Phase 1 — code-complete
 on branch, pending release; latest published release is v0.3.0).
 
 Beads are tracked with `tbd` (git-native, on the `tbd-sync` branch). View them with:
@@ -20,7 +20,7 @@ tbd show <id>      # details + working notes (e.g. tbd show chopdiff-1x4u)
 
 ### Flexible Unified Document Model (DocGraph): `docs/project/specs/active/`
 
-**Phase 1 code-complete (pending release with v0.4.0); later phases remain.** A
+**Phase 1 code-complete (pending release with v0.3.1); later phases remain.** A
 source-grounded, JSON-serializable `DocGraph` projected from `TextDoc`: a stable node
 table (each node tagged with its parse **layer**) and derived views, and one general
 `collect()` query (values/counts/groupings via standard Python) at any scope
@@ -48,7 +48,7 @@ offset-containment queries. Subsumes the multi-level block-tallies work.
 ### Robustness Hardening: `docs/project/specs/active/`
 
 Correctness and API-contract fixes from the engineering review, **re-reviewed 2026-05-29
-against current v0.4.0 code**. Findings already fixed (console script, absolute offsets,
+against current v0.3.1 branch code**. Findings already fixed (console script, absolute offsets,
 `from_text` doc honesty, publish `--locked`, quiet tests) are recorded as resolved; the
 open items are verified with current evidence and grouped into three phases.
 
@@ -65,7 +65,7 @@ open items are verified with current evidence and grouped into three phases.
 
 ## Completed
 
-### Block-Aware Document Model / Normalized Form: Shipped in v0.4.0 (PR #12)
+### Block-Aware Document Model / Normalized Form: Shipping in v0.3.1 (PR #12)
 
 `TextDoc` gained exact `[start, end)` spans, a section/TOC hierarchy with rolled-up
 stats, inline-link rollups, link-aware sentences, and an opt-in structural block
@@ -104,7 +104,7 @@ Surfaced by the review reconciliation; fold into the robustness spec when picked
 ## Archive
 
 - [docs/project/specs/archive/plan-2026-05-26-block-aware-doc.md](docs/project/specs/archive/plan-2026-05-26-block-aware-doc.md)
-  (completed; shipped in v0.4.0). Superseded as a living doc by `docs/textdoc-spec.md`.
+  (completed; shipping in v0.3.1). Superseded as a living doc by `docs/textdoc-spec.md`.
 - [docs/project/specs/archive/plan-2026-05-26-markdown-block-segmentation.md](docs/project/specs/archive/plan-2026-05-26-markdown-block-segmentation.md)
   (superseded by the block-aware-doc plan; proposed a parallel `MarkdownDoc` module;
   the chosen direction extends `TextDoc` in place).

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,8 @@
 # chopdiff: Open Work
 
 A concise index of planned work, the specs that describe it, and the beads that track
-it. Status as of 2026-05-29 (v0.4.0 in review on PR #12).
+it. Status as of 2026-06-02 (v0.4.0 — block-aware model + DocGraph Phase 1 — code-complete
+on branch, pending release; latest published release is v0.3.0).
 
 Beads are tracked with `tbd` (git-native, on the `tbd-sync` branch). View them with:
 
@@ -19,27 +20,30 @@ tbd show <id>      # details + working notes (e.g. tbd show chopdiff-1x4u)
 
 ### Flexible Unified Document Model (DocGraph): `docs/project/specs/active/`
 
-Design settled, ready to build. A source-grounded, JSON-serializable `DocGraph` projected
-from `TextDoc`: a stable node table (each node tagged with its parse **layer**) and derived
-views, and one general `collect()` query (values/counts/groupings via standard Python) at any
-scope (doc/section/block), recursive, over blocks and inline items, with the source-canonical
+**Phase 1 code-complete (pending release with v0.4.0); later phases remain.** A
+source-grounded, JSON-serializable `DocGraph` projected from `TextDoc`: a stable node
+table (each node tagged with its parse **layer**) and derived views, and one general
+`collect()` query (values/counts/groupings via standard Python) at any scope
+(doc/section/block), recursive, over blocks and inline items, with the source-canonical
 `SpanRef` reference model and composable `include`/`detail` serialization. The
 **layered-parsing lens** (E9) frames the views as parse layers (textual / markdown /
 document / synthetic) over one offset space, with cross-layer relationships as
-offset-containment queries; the synthetic (marker-tag) layer and future cross-layer structural
-edits are later phases that drop in via four cheap Phase-1 hooks. Subsumes the multi-level
-block-tallies work.
+offset-containment queries. Subsumes the multi-level block-tallies work.
 
+- Shipped in Phase 1 (on branch): recursive layer-tagged node table, `base_blocks()`,
+  `collect()` with `subtree_of=`/`within=`/`overlaps=` relations, `SpanRef`
+  (exact-quote resolution), the `DocGraph` Pydantic projection (`DocGraph/v0.1`),
+  `to_yaml()`, and the `chopdiff.docs.debug` dumper.
+- Remaining (later phases, via the four Phase-1 hooks): the synthetic (marker-tag)
+  layer, cross-layer structural edits, and `SpanRef` fuzzy re-anchoring.
 - Spec: [plan-2026-05-29-unified-document-model.md](docs/project/specs/active/plan-2026-05-29-unified-document-model.md)
-  (status: **all nine decisions settled (DR-1..DR-6) and E9 layered lens; Phase 0
-  design-of-record current; no code yet**). Design of record:
-  [docs/textdoc-spec.md](docs/textdoc-spec.md).
+  (status: **decisions settled (DR-1..DR-6) and E9 layered lens; Phase 1 implemented**).
+  Design of record: [docs/textdoc-spec.md](docs/textdoc-spec.md).
 - Research: the [document-model survey](docs/project/research/research-2026-05-29-document-model.md),
   [span-references](docs/project/research/research-2026-05-30-span-references.md), and
   [multi-layer parsing](docs/project/research/research-2026-05-30-multilayer-parsing.md) briefs.
-- Beads: epic `chopdiff-8q8q`; decisions gate `chopdiff-0vy6` closed. **Next: break Phase 1
-  (recursive node model, `layer` field, `collect()`, offset-containment, and `SpanRef`) into
-  implementation beads.**
+- Beads: epic `chopdiff-8q8q`; decisions gate `chopdiff-0vy6` closed. **Next: break the
+  remaining phases (synthetic layer, cross-layer edits, fuzzy re-anchoring) into beads.**
 
 ### Robustness Hardening: `docs/project/specs/active/`
 

--- a/docs/textdoc-spec.md
+++ b/docs/textdoc-spec.md
@@ -4,7 +4,7 @@
 Python core and the `DocGraph` serialized projection.
 The design is settled (decision records DR-1..DR-6 in
 [`plan-2026-05-29-unified-document-model.md`](project/specs/active/plan-2026-05-29-unified-document-model.md));
-see §14 for what is implemented (v0.4.0) versus in progress.
+see §14 for what is implemented (v0.3.1) versus in progress.
 Dated plans under `docs/project/specs/` describe the incremental work toward this
 design.
 
@@ -432,7 +432,7 @@ doc.collect(within=section_id, kinds={NodeKind.link})      # links in a section
 Slice-by-block-type, per-section rollups, and element rollups are all expressions of
 this one primitive; relationships are node edges.
 There are no `tables()`/`code_blocks()` shortcuts to maintain.
-(The v0.4.0 `block_type_counts()` convenience accessors are superseded by `collect()`;
+(The v0.3.1 `block_type_counts()` convenience accessors are superseded by `collect()`;
 see §14.)
 
 **Query vs. partition; do not conflate.** `collect()` is a *query*: it gathers matching
@@ -602,11 +602,12 @@ Non-obvious choices, each grounded in a principle:
 
 ## 14. Implementation Status
 
-- **Shipped in v0.4.0:** exact spans; the opt-in structural block tree `blocks()`
-  (boundaries and spans from flowmark, no regex scanner); sections/TOC/size rollups;
-  inline-link rollups and link-aware sentences; `ordered_list`/density-invariant lists;
-  per-section blocks; and **top-level** `block_type_counts()`.
-- **Implemented (post-v0.4.0):** the recursive node table (containers fully populate
+- **Shipping in v0.3.1 (block-aware layer):** exact spans; the opt-in structural block
+  tree `blocks()` (boundaries and spans from flowmark, no regex scanner);
+  sections/TOC/size rollups; inline-link rollups and link-aware sentences;
+  `ordered_list`/density-invariant lists; per-section blocks; and **top-level**
+  `block_type_counts()`.
+- **Also in v0.3.1 (DocGraph layer):** the recursive node table (containers fully populate
   children, including blockquote and list-item block children); `base_blocks()`
   sequential partition with its non-overlapping cover invariant; the single `collect()`
   primitive (superseding `block_type_counts()`; migration:
@@ -629,7 +630,7 @@ Non-obvious choices, each grounded in a principle:
   [`research-2026-05-30-span-references.md`](project/research/research-2026-05-30-span-references.md),
   and the layered-parsing brief
   [`research-2026-05-30-multilayer-parsing.md`](project/research/research-2026-05-30-multilayer-parsing.md).
-- Completed block-aware plan (v0.4.0):
+- Completed block-aware plan (shipping in v0.3.1):
   [`plan-2026-05-26-block-aware-doc.md`](project/specs/archive/plan-2026-05-26-block-aware-doc.md).
 - flowmark v0.7.1 API: `flowmark.atomic_spans` (`iter_atomic_spans`,
   `split_sentences_with_spans`, named `AtomicSpan`s) and `flowmark.markdown_ast`


### PR DESCRIPTION
Prepares the next release (**v0.3.1**) and lands the DocGraph node-model work on top of the block-aware document model.

## What's here

Relative to `main`, this branch carries the DocGraph node model and supporting perf/correctness work (already reviewed in PRs #14–#16), plus release-prep doc commits:

- **CHANGELOG:** folded the `Unreleased` DocGraph section into a single comprehensive release entry, grouped like v0.3.0 (Breaking Changes / New Features / Fixes / Internal / Documentation / Dependencies / Compatibility / Full Changelog). The block-aware model and DocGraph Phase 1 ship together.
- **TODO.md / textdoc-spec.md:** refreshed status — DocGraph Phase 1 is code-complete (not "no code yet"); shipped-vs-remaining split; renamed the release.

## Release framing

- Latest published release/tag is **v0.3.0**; this ships as **v0.3.1**.
- Versioned as a **patch** despite two breaking changes vs v0.3.0 (`BlockType.list` bullet-only; span-aware default sentence splitting): per maintainer call, those touch only the very new, not-yet-relied-upon block-type/sentence-splitting surface added in v0.3.0. The changelog notes this policy exception. Everything else is additive (no public symbol removed since v0.3.0).

Note: dated internal planning/research specs under `docs/project/` still reference the old `v0.4.0` working codename; left as archival point-in-time records.

## Status

- `make lint` clean, 313 tests pass (after `uv sync --all-extras`).

Release is tag-driven: merge to `main`, then push a `v0.3.1` tag to trigger `publish.yml` → PyPI.

https://claude.ai/code/session_01YCwJZXQK5TysYhuo5zuKaU