### PR TITLE
Post-extraction cleanup + design-of-record sync + FlexDoc Stage-2 runbook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,3 +103,32 @@ jobs:
       # SUPPLY-CHAIN-SECURITY.md (Audit-Gate Ignores).
       - name: Audit dependencies for known vulnerabilities
         run: uv run --locked --all-extras --group audit pip-audit --ignore-vuln PYSEC-2026-196
+
+  # Packaging check: the single chopdiff wheel must ship BOTH import roots (flexdoc and
+  # chopdiff) and import cleanly from an isolated install — not just from the source tree.
+  # This guards the two-import-root layout (one wheel, two packages) introduced by the
+  # FlexDoc extraction. See plan-2026-06-11-flexdoc-extraction.md.
+  wheel-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (official GitHub action)
+        uses: actions/checkout@v6
+        with:
+          # Needed for the dynamic-versioning build backend (reads git tags).
+          fetch-depth: 0
+
+      - name: Install uv (official Astral action)
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "0.11.12"
+          enable-cache: true
+
+      - name: Build the wheel
+        run: uv build --wheel
+
+      - name: Install the wheel in an isolated venv and import both packages
+        run: |
+          uv venv /tmp/wheelsmoke
+          VENV_PY=/tmp/wheelsmoke/bin/python
+          uv pip install --python "$VENV_PY" dist/*.whl
+          "$VENV_PY" -c "import flexdoc, chopdiff; from flexdoc.docs import TextDoc; from chopdiff.transforms import sliding_para_window; print('wheel imports OK:', flexdoc.__name__, chopdiff.__name__, TextDoc.__name__)"

--- a/README.md
+++ b/README.md
@@ -267,10 +267,10 @@ of the people, by the people, for the people, shall not perish from the earth.
 
 Input document: 1466 bytes (17 lines, 1 paras, 10 sents, 264 words, ~383 tok)
 
-INFO:chopdiff.docs.sliding_transforms:Sliding word transform: Begin on doc: total 575 wordtoks, 1466 bytes, 1 windows, windowing size=2048, shift=1792, min_overlap=8 wordtoks
-INFO:chopdiff.docs.sliding_transforms:Sliding word transform window 1/1 (575 wordtoks, 1466 bytes), at 0 wordtoks so far
+INFO:chopdiff.transforms.sliding_transforms:Sliding word transform: Begin on doc: total 575 wordtoks, 1466 bytes, 1 windows, windowing size=2048, shift=1792, min_overlap=8 wordtoks
+INFO:chopdiff.transforms.sliding_transforms:Sliding word transform window 1/1 (575 wordtoks, 1466 bytes), at 0 wordtoks so far
 INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
-INFO:chopdiff.docs.sliding_transforms:Accepted transform changes:
+INFO:chopdiff.transforms.sliding_transforms:Accepted transform changes:
     TextDiff: add/remove +3/-3 out of 575 total:
     at pos    0 keep    1 toks:   ⎪four⎪
     at pos    1 keep   62 toks:   ⎪ score and seven years ago our fathers brought forth on this continent, a new nation, conceived in Liberty, and dedicated to the proposition that all men are created equal.⎪
@@ -283,14 +283,14 @@ INFO:chopdiff.docs.sliding_transforms:Accepted transform changes:
     at pos  350 repl    1 toks: - ⎪<-SENT-BR->⎪
                 repl    1 toks: + ⎪<-PARA-BR->⎪
     at pos  351 keep  224 toks:   ⎪It is for us the living, rather, to be dedicated here to the unfinished work which they who fought here have thus far so nobly advanced.<-SENT-BR->It is rather for us to be here dedicated to the great task remaining before us—that from these honored dead we take increased devotion to that cause for which they gave the last full measure of devotion—that we here highly resolve that these dead shall not have died in vain—that this nation, under God, shall have a new birth of freedom—and that government of the people, by the people, for the people, shall not perish from the earth.⎪
-INFO:chopdiff.docs.sliding_transforms:Filtering extraneous changes:
+INFO:chopdiff.transforms.sliding_transforms:Filtering extraneous changes:
     TextDiff: add/remove +1/-1 out of 575 total:
     at pos    0 repl    1 toks: - ⎪four⎪
                 repl    1 toks: + ⎪Four⎪
-INFO:chopdiff.docs.sliding_transforms:Word token changes:
+INFO:chopdiff.transforms.sliding_transforms:Word token changes:
     Accepted: add/remove +3/-3 out of 575 total
     Rejected: add/remove +1/-1 out of 575 total
-INFO:chopdiff.docs.sliding_transforms:Sliding word transform: Done, output total 575 wordtoks
+INFO:chopdiff.transforms.sliding_transforms:Sliding word transform: Done, output total 575 wordtoks
 
 Output document: 1469 bytes (7 lines, 4 paras, 10 sents, 264 words, ~387 tok)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,13 @@
 # chopdiff: Open Work
 
 A concise index of planned work, the specs that describe it, and the beads that track
-it. Status as of 2026-06-02 (v0.3.1 — block-aware model + DocGraph Phase 1 — code-complete
-on branch, pending release; latest published release is v0.3.0).
+it. Status as of 2026-06-11. v0.3.1 (block-aware model + DocGraph Phase 1) is released.
+Since then, on `main`: the document model was extracted into the **`flexdoc`** package
+(one wheel, two import roots — `src/flexdoc` and `src/chopdiff`); typed code/table/list
+block metadata and `NodeKind.footnote_ref` were added; `block_type_counts()` was removed;
+and a `read_time` util was salvaged. See CHANGELOG **Unreleased** and
+[plan-2026-06-11-flexdoc-extraction.md](docs/project/specs/active/plan-2026-06-11-flexdoc-extraction.md)
+(Stage 1 done; Stages 2–4 — extract to a new repo and publish — are the next program).
 
 Beads are tracked with `tbd` (git-native, on the `tbd-sync` branch). View them with:
 
@@ -33,7 +38,7 @@ offset-containment queries. Subsumes the multi-level block-tallies work.
 - Shipped in Phase 1 (on branch): recursive layer-tagged node table, `base_blocks()`,
   `collect()` with `subtree_of=`/`within=`/`overlaps=` relations, `SpanRef`
   (exact-quote resolution), the `DocGraph` Pydantic projection (`DocGraph/v0.1`),
-  `to_yaml()`, and the `chopdiff.docs.debug` dumper.
+  `to_yaml()`, and the `flexdoc.docs.debug` dumper.
 - Remaining (later phases, via the four Phase-1 hooks): the synthetic (marker-tag)
   layer, cross-layer structural edits, and `SpanRef` fuzzy re-anchoring.
 - Spec: [plan-2026-05-29-unified-document-model.md](docs/project/specs/active/plan-2026-05-29-unified-document-model.md)
@@ -65,7 +70,7 @@ open items are verified with current evidence and grouped into three phases.
 
 ## Completed
 
-### Block-Aware Document Model / Normalized Form: Shipping in v0.3.1 (PR #12)
+### Block-Aware Document Model / Normalized Form: Shipped in v0.3.1 (PR #12)
 
 `TextDoc` gained exact `[start, end)` spans, a section/TOC hierarchy with rolled-up
 stats, inline-link rollups, link-aware sentences, and an opt-in structural block
@@ -74,7 +79,7 @@ chopdiff's regex block scanner with flowmark's authoritative block spans (flowma
 0.7.1), and Phase 6 added the normalized-form views: `BlockType.ordered_list`,
 density-invariant lists
 (`Block.tight`), `Section.blocks()`, and derived `block_type_counts()` rollups (no stored
-counts).
+counts; `block_type_counts()` was later removed post-v0.3.1, superseded by `collect()`).
 
 - Design of record: [docs/textdoc-spec.md](docs/textdoc-spec.md).
 - Implementation plan (archived): [plan-2026-05-26-block-aware-doc.md](docs/project/specs/archive/plan-2026-05-26-block-aware-doc.md).
@@ -94,12 +99,17 @@ counts).
 
 ## Known Gaps Not Yet in Any Plan
 
-Surfaced by the review reconciliation; fold into the robustness spec when picked up:
+Surfaced by the review reconciliation:
 
 - `parse_tag()` extracts only double-quoted `\w+` attributes (misses single-quoted,
-  unquoted, hyphenated, boolean attrs).
-- No root-level `chopdiff` public API; no decision recorded on whether to add one.
-- CI runs Ubuntu only; no wheel install/import smoke test.
+  unquoted, hyphenated, boolean attrs). The limitation is documented as intentional;
+  hardening it is a candidate for the FlexDoc public-surface work (extraction Stage 3).
+- No root-level public API on `chopdiff`/`flexdoc`; the decision is deferred to FlexDoc
+  Stage 3 (settle the document-layer public surface, including root-level re-exports).
+- The deprecated `collect()` aliases `scope=`/`contains=` remain; remove when the public
+  surface is settled (FlexDoc Stage 3).
+- CI runs Ubuntu only. (A wheel install/import smoke test is added in the post-extraction
+  cleanup, validating the two-import-root wheel.)
 
 ## Archive
 

--- a/docs/project/specs/active/plan-2026-05-31-golden-doc-testing.md
+++ b/docs/project/specs/active/plan-2026-05-31-golden-doc-testing.md
@@ -17,7 +17,7 @@ source documents, each converted by the model and serialized several ways, with 
 serializations committed as golden artifacts and compared on every run.
 
 The serializer is built as a **reusable developer tool**, not test-only glue: a public
-`chopdiff.docs.debug` dumper that can take any document and emit its model views in
+`flexdoc.docs.debug` dumper that can take any document and emit its model views in
 clean standard formats.
 Source documents are **Markdown with YAML frontmatter** (the frontmatter carries the
 test’s options); golden outputs are **pure, deterministic YAML**. We reuse
@@ -30,7 +30,7 @@ guarantees (cover, exact spans, round-trip, cross-serialization consistency).
 
 ## Goals
 
-- **A reusable debug dumper (public).** `chopdiff.docs.debug` turns any `TextDoc` /
+- **A reusable debug dumper (public).** `flexdoc.docs.debug` turns any `TextDoc` /
   `DocGraph` into clean, standard-format views (a multi-view report, the DocGraph, the
   reassembled source) usable from a REPL, a script, or the test harness.
 - **Clean YAML for DocGraph.** A deterministic, readable YAML serialization of
@@ -72,7 +72,7 @@ guarantees (cover, exact spans, round-trip, cross-serialization consistency).
 
 ### Components
 
-1. **`chopdiff.docs.debug` (public dumper).** Pure functions over public API:
+1. **`flexdoc.docs.debug` (public dumper).** Pure functions over public API:
    - `doc_report(doc: TextDoc) -> str` — the multi-view report as clean YAML: source
      metadata (sha, length, size summary), base-block partition with `cover_ok`,
      sections / TOC with rolled-up sizes, the full node table (id, layer, kind, span,
@@ -123,7 +123,7 @@ See Open Decisions for runtime-vs-extra placement.
 
 ### API Changes
 
-- **Additive (public):** new module `chopdiff.docs.debug` (`doc_report`,
+- **Additive (public):** new module `flexdoc.docs.debug` (`doc_report`,
   `doc_graph_yaml`, `dump_views`) and a `DocGraph.to_yaml()` method.
   No existing surface changes.
 
@@ -134,7 +134,7 @@ See Open Decisions for runtime-vs-extra placement.
 - [x] Adopt `frontmatter-format` per `SUPPLY-CHAIN-SECURITY.md` (cool-off entry,
   lockfile).
 - [x] Add `DocGraph.to_yaml()` (clean, key-sorted YAML via `to_yaml_string`); keep JSON.
-- [x] Build `chopdiff.docs.debug` with `doc_report`, `doc_graph_yaml`, `dump_views`,
+- [x] Build `flexdoc.docs.debug` with `doc_report`, `doc_graph_yaml`, `dump_views`,
   emitting deterministic clean YAML; export it.
 - [x] A few inline/unit checks that the dumper is deterministic (same input → identical
   bytes) and that YAML re-parses to the expected structure.

--- a/docs/project/specs/active/plan-2026-06-11-flexdoc-extraction.md
+++ b/docs/project/specs/active/plan-2026-06-11-flexdoc-extraction.md
@@ -328,12 +328,86 @@ are mapped for the program and detailed on their own branches.
 
 ### Stage 2: extract and publish FlexDoc (later branch / new repo)
 
-- [ ] New `flexdoc` repo; move `src/flexdoc/` + its tests (preserve history where practical).
-- [ ] `flexdoc` `pyproject.toml`: build/versioning, dependency subset, mirrored supply-chain
-      and lint/type config; `flexdoc` test suite green standalone.
-- [ ] Publish `flexdoc` to PyPI (confirm name).
-- [ ] chopdiff: drop moved modules, depend on `flexdoc`, prune flexdoc-only deps, rewrite
-      imports; chopdiff suite green against the published `flexdoc`.
+This is a **handoff runbook for a fresh agent working in a new repo.** Stage 1 already did
+the hard part (the one-way boundary is proven and enforced), so this is copy-and-rewire
+plus packaging. The partition below was computed from the merged Stage-1 tree; re-verify
+each fact against the source before relying on it (commands given inline).
+
+**Step 1 — Create the new `flexdoc` repo and copy the package.**
+
+- [ ] Copy `src/flexdoc/` verbatim into the new repo as `src/flexdoc/` (the whole package:
+      `docs/`, `html/`, `util/`, `__init__.py`, `py.typed`). Inline tests (`## Tests`
+      sections in e.g. `block_info.py`, `read_time.py`, `wordtoks.py`) travel with their
+      modules. Preserve git history if practical (`git filter-repo --path src/flexdoc` or
+      `git subtree split`), else a plain copy is fine.
+- [ ] Copy the document-model **tests**: `tests/docs/`, `tests/html/`, `tests/util/`, and
+      `tests/golden/` (including `tests/golden/documents/`, `tests/golden/expected/`, and
+      `tests/golden/README.md`), plus `tests/__init__.py`. **Do not** copy
+      `tests/test_package_boundary.py` (the boundary becomes a real package dependency) or
+      `tests/test_supply_chain.py` (write a fresh one for the new repo's settings).
+      `tests/divs/` and `tests/transforms/` stay in chopdiff.
+- [ ] Copy the document-model **examples** that import only `flexdoc.*`
+      (`examples/normalized_form.py`, `examples/doc_structure.py`, and
+      `examples/backfill_timestamps.py` — it uses `flexdoc.html`). `insert_para_breaks.py`
+      uses `chopdiff.transforms`, so it stays in chopdiff. Verify with
+      `grep -l "chopdiff\.\(transforms\|divs\)" examples/*.py`.
+- [ ] Copy the **design history** (this model's docs): `docs/textdoc-spec.md` (the design
+      of record — it already describes the flexdoc document model), the research briefs
+      `docs/project/research/*`, and the plan specs `plan-2026-05-29-unified-document-model.md`,
+      `plan-2026-06-11-structural-metadata.md`, `plan-2026-05-31-doc-model-refinements.md`,
+      `plan-2026-05-31-golden-doc-testing.md`, and this extraction plan. Leave chopdiff's
+      own copies in place (or cross-link).
+
+**Step 2 — Scaffold the new repo's tooling (mirror chopdiff's).**
+
+- [ ] `flexdoc/pyproject.toml`: `[project] name = "flexdoc"`, `requires-python = ">=3.11"`;
+      build-system `hatchling` + `uv-dynamic-versioning`;
+      `[tool.hatch.build.targets.wheel] packages = ["src/flexdoc"]`. Copy chopdiff's
+      `[tool.uv] exclude-newer` cool-off and `[tool.uv.exclude-newer-package]` exceptions,
+      and the `[tool.ruff]`/`[tool.basedpyright]` (`include = ["src", "tests"]`)/
+      `[tool.codespell]`/`[tool.pytest.ini_options]` (`testpaths = ["src", "tests"]`) blocks.
+- [ ] **Dependencies** (`[project.dependencies]`): `flowmark`, `marko`, `cydifflib`,
+      `funlog`, `regex`, `strif`, `frontmatter-format`, `pydantic`, `prettyfmt`,
+      `selectolax`, `typing-extensions`. **Optional extra** `extras = ["simplemma"]` (only
+      `flexdoc/util/lemmatize.py` uses it). Re-derive and confirm the exact set with:
+      `grep -rhoE '^(from|import) [a-z_]+' src/flexdoc | grep -oE '^[a-z_]+ [a-z_]+' | awk '{print $2}' | sort -u`
+      then drop stdlib and `flexdoc` itself. Keep version floors at chopdiff's current pins.
+- [ ] Copy `Makefile`, `devtools/lint.py`, `.github/workflows/ci.yml` (including the
+      `wheel-smoke` job and the audit-gate `--ignore-vuln` note),
+      `.github/workflows/publish.yml`, `SUPPLY-CHAIN-SECURITY.md`, `.gitignore`, `LICENSE`,
+      and a fresh `README.md` + `CHANGELOG.md`. `src/flexdoc/py.typed` is already present.
+- [ ] `uv lock` to generate `flexdoc`'s own committed lockfile; `make install`.
+
+**Step 3 — Verify `flexdoc` standalone.**
+
+- [ ] `make lint` and `make test` green in the new repo (the doc-model suite + goldens run
+      unchanged; regen goldens only if intentionally changed).
+- [ ] `uv build --wheel` produces `flexdoc-*.whl`; isolated import smoke test
+      (`uv pip install` into a throwaway venv, `import flexdoc; from flexdoc.docs import TextDoc`).
+      The boundary is now structural: `flexdoc` has no `chopdiff` dependency at all.
+
+**Step 4 — Publish `flexdoc`.**
+
+- [ ] Confirm the distribution name `flexdoc` is available on PyPI (`uv pip index versions
+      flexdoc`, or check pypi.org); pick an alternative if taken (see Open Questions).
+- [ ] Tag and publish `flexdoc 0.1.0` (its own independent version line) via `publish.yml`.
+
+**Step 5 — Rewire chopdiff to depend on the external `flexdoc` (the breaking release).**
+
+- [ ] In chopdiff: `git rm -r src/flexdoc/` and remove the moved tests
+      (`tests/{docs,html,util,golden}/`) and `tests/test_package_boundary.py`. The
+      `chopdiff.{transforms,divs}` code already imports `flexdoc.*`, so **no import rewrite
+      is needed** — those imports now resolve to the external package.
+- [ ] `pyproject.toml`: add `flexdoc>=<first published>`; **remove** the now-flexdoc-only
+      deps (`marko`, `cydifflib`, `funlog`, `regex`, `strif`, `frontmatter-format`,
+      `pydantic`, `selectolax`) and the `extras`/`simplemma` group; keep `flowmark` and
+      `prettyfmt` (chopdiff's `transforms`/`divs` import them directly). Remove `src/flexdoc`
+      from the wheel target (back to `packages = ["src/chopdiff"]`). `uv lock`.
+- [ ] `make lint` and `make test` green against the published `flexdoc`; the `wheel-smoke`
+      job now imports only `chopdiff` (with `flexdoc` pulled as a dependency).
+- [ ] `CHANGELOG.md`: this is chopdiff's first release depending on external `flexdoc` — a
+      **breaking** release (the `chopdiff.docs|html|util.*` paths are gone). Note the
+      migration (`pip install flexdoc`; `chopdiff.docs.* -> flexdoc.docs.*`).
 
 ### Stage 3: FlexDoc as a first-class, extensible document-layer API (later, its own repo)
 

--- a/docs/project/specs/active/plan-2026-06-11-structural-metadata.md
+++ b/docs/project/specs/active/plan-2026-06-11-structural-metadata.md
@@ -255,9 +255,9 @@ The bulk: #18 / #19 / #20, plus the two adjacent cleanups that share the release
   `node_table._build_markdown_nodes` (additive keys; existing `tight`/`ordered` unchanged).
 - [ ] Reuse the extractors in `Paragraph._block_info`; add `Paragraph.code_info` /
   `.table_info` / `.list_info` with the density caveat in their docstrings.
-- [ ] Remove `TextDoc.block_type_counts()` / `Section.block_type_counts()`; migrate internal
+- [x] Remove `TextDoc.block_type_counts()` / `Section.block_type_counts()`; migrate internal
   callers/tests/examples to `collect()` / `blocks()`; record the migration in `CHANGELOG.md`.
-- [ ] Salvage `src/chopdiff/util/read_time.py` (with its inline tests) from the abandoned
+- [x] Salvage `src/chopdiff/util/read_time.py` (with its inline tests) from the abandoned
   branch; confirm its `prettyfmt.fmt_timedelta` dependency is already satisfied.
 - [ ] Update `docs/textdoc-spec.md` §5 (block-type model: per-kind typed `attrs`) and §9
   (note typed attrs are element attributes, not rollups; `block_type_counts()` removed);
@@ -268,7 +268,7 @@ The bulk: #18 / #19 / #20, plus the two adjacent cleanups that share the release
 
 Independent of Phase 1: #21 and #22.
 
-- [ ] Add `NodeKind.footnote_ref` and include it in `collect.INLINE_KINDS`.
+- [x] Add `NodeKind.footnote_ref` and include it in `collect.INLINE_KINDS`.
 - [ ] In `node_table._build_inline_nodes`, recognize footnote-reference atomics (a
   `markdown_link` atomic whose text starts `[^` and is not a `:`-suffixed definition); emit a
   `footnote_ref` node with exact span and `attrs={"label": ...}`. Add tests: a `[^1]`

--- a/docs/textdoc-spec.md
+++ b/docs/textdoc-spec.md
@@ -1,7 +1,8 @@
 # TextDoc and DocGraph: Design Specification
 
-**Status:** Definitive front-to-back design of chopdiff’s document model: the `TextDoc`
-Python core and the `DocGraph` serialized projection.
+**Status:** Definitive front-to-back design of the document model — the `TextDoc`
+Python core and the `DocGraph` serialized projection — now housed in the `flexdoc`
+package (extracted from chopdiff; built in this repo, see §14).
 The design is settled (decision records DR-1..DR-6 in
 [`plan-2026-05-29-unified-document-model.md`](project/specs/active/plan-2026-05-29-unified-document-model.md));
 see §14 for what is implemented (v0.3.1) versus in progress.
@@ -283,6 +284,17 @@ lists, so `len(list.children)` and any tally are density-invariant.
 Density is metadata, not structure: a `tight: bool` on the list (CommonMark semantics);
 the flag never enters a tally.
 
+**Typed per-block metadata.** Code, table, and list blocks carry parser-authoritative
+typed metadata (`flexdoc.docs.block_info`): `CodeInfo` (`language`, `line_count`),
+`TableInfo` (`rows`, `cols`, `cells`, `alignments`), and `ListInfo` (`ordered`, `start`,
+`max_depth`, `item_count`). It is computed once where the marko element is in hand and
+exposed on the structural `Block` (`Block.code_info`/`.table_info`/`.list_info` — the
+density-invariant source of truth) and, as a convenience carrying the editing-view density
+caveat, on `Paragraph`. The same facts are flattened into the markdown node's `attrs`, so
+they flow into `collect()`/`DocGraph`. Extraction is parser-authoritative (marko element
+attributes, never a regex over source); a table column with no alignment marker is
+`"default"`, not `None`, so `alignments` is always explicit strings of length `cols`.
+
 ## 6. Block Views: Structural Tree and Sequential Base-Block List
 
 **Terminology.** To avoid overloading “block”:
@@ -324,7 +336,7 @@ The structure is cross-checked against marko in tests.
 A **base block** is a `BaseBlock` wrapping a block node (`Block`) with a `depth`; the
 **base-block list** is a *partition* of the document: the ordered sequence of base
 blocks, each carrying its `depth`. `TextDoc.base_blocks()` is a thin method over the
-`chopdiff.docs.base_blocks.base_blocks(text, *, item_partition_depth=6)` free function
+`flexdoc.docs.base_blocks.base_blocks(text, *, item_partition_depth=6)` free function
 (the partition lives in its own module, distinct from the recursive tree in
 `block_tree.py`). It is the view for block-by-block pipelines and outline UIs that
 move/resequence blocks (e.g. Notion-style drag-and-drop, where every item is a draggable
@@ -381,10 +393,10 @@ A derived hierarchy over heading nodes, no re-parse:
 
 ## 8. Inline Elements and Links
 
-Inline elements (links, code spans, images, …) are **first-class nodes** whose `parent`
-is their containing block, with computed `section`/`sentence` associations, so
-block↔inline relationships are node edges, and “links in section 3” is a scoped
-`collect(kinds={link})`.
+Inline elements (links, code spans, images, inline HTML, footnote references, …) are
+**first-class nodes** whose `parent` is their containing block, with computed
+`section`/`sentence` associations, so block↔inline relationships are node edges, and
+“links in section 3” is a scoped `collect(kinds={link})`.
 
 - `Link(text, url, title, span)`: identity from `flowmark.markdown_ast.extract_links`
   (reference links resolved, escapes honored, autolinks/images handled), which carries
@@ -393,6 +405,10 @@ block↔inline relationships are node edges, and “links in section 3” is a s
   `flowmark.atomic_spans.iter_atomic_spans` (`markdown_link` / `autolink` / `bare_url`);
   reference links keep identity but no exact span.
 - `link → sentence` via `sentence_at_offset(link.span[0])`.
+- **`footnote_ref`**: a footnote reference `[^label]` is a first-class inline node
+  (`NodeKind.footnote_ref`) carrying its `label` in `attrs` and an exact span, collected
+  like any inline kind (`collect(kinds={NodeKind.footnote_ref}, recursive=True)`). A
+  footnote *definition* (`[^label]:`) is a `footnote` block, not a reference.
 
 ## 9. Derived Views and Rollups
 
@@ -432,8 +448,8 @@ doc.collect(within=section_id, kinds={NodeKind.link})      # links in a section
 Slice-by-block-type, per-section rollups, and element rollups are all expressions of
 this one primitive; relationships are node edges.
 There are no `tables()`/`code_blocks()` shortcuts to maintain.
-(The v0.3.1 `block_type_counts()` convenience accessors are superseded by `collect()`;
-see §14.)
+(The v0.3.1 `block_type_counts()` convenience accessors have since been **removed**; use
+`collect()` or `Counter(b.type for b in doc.blocks())`. See §14.)
 
 **Query vs. partition; do not conflate.** `collect()` is a *query*: it gathers matching
 nodes and the results may **overlap** their containers (a table nested in a blockquote
@@ -602,19 +618,25 @@ Non-obvious choices, each grounded in a principle:
 
 ## 14. Implementation Status
 
-- **Shipping in v0.3.1 (block-aware layer):** exact spans; the opt-in structural block
+- **Shipped in v0.3.1 (block-aware layer):** exact spans; the opt-in structural block
   tree `blocks()` (boundaries and spans from flowmark, no regex scanner);
   sections/TOC/size rollups; inline-link rollups and link-aware sentences;
-  `ordered_list`/density-invariant lists; per-section blocks; and **top-level**
-  `block_type_counts()`.
+  `ordered_list`/density-invariant lists; and per-section blocks. (v0.3.1 also shipped
+  top-level `block_type_counts()`, since **removed** — see the unreleased changes below.)
 - **Also in v0.3.1 (DocGraph layer):** the recursive node table (containers fully populate
   children, including blockquote and list-item block children); `base_blocks()`
   sequential partition with its non-overlapping cover invariant; the single `collect()`
-  primitive (superseding `block_type_counts()`; migration:
-  `Counter(n.kind for n in doc.collect(recursive=True))`); composable `include` layers
-  and `detail` payload options; the `DocGraph` Pydantic schema ("DocGraph/v0.1"); and the
-  `SpanRef` contract with exact + prefix/suffix quote resolution (fuzzy re-anchoring
-  deferred).
+  primitive; composable `include` layers and `detail` payload options; the `DocGraph`
+  Pydantic schema ("DocGraph/v0.1"); and the `SpanRef` contract with exact + prefix/suffix
+  quote resolution (fuzzy re-anchoring deferred).
+- **Unreleased (post-v0.3.1):** the document model was **extracted into the `flexdoc`
+  package** (`flexdoc.docs`/`html`/`util`; `chopdiff` keeps the diff/transform layer and
+  builds on `flexdoc` — one wheel, two import roots for now). Added: **typed per-block
+  metadata** — `CodeInfo` (`language`, `line_count`), `TableInfo` (`rows`, `cols`,
+  `cells`, `alignments`), `ListInfo` (`ordered`, `start`, `max_depth`, `item_count`) — on
+  `Block`/`Paragraph` and flattened into markdown node `attrs` (§5); the
+  **`footnote_ref`** inline kind (§8); and a `read_time` util. **Removed:**
+  `block_type_counts()` (use `collect()` / `Counter(b.type for b in doc.blocks())`).
 - **In progress:** annotation layer, synthetic layer (re-expressing `TextNode` tag
   chunking as a layer), cross-layer structural edits, and operation/provenance/layout
   layers. Tracked by epic `chopdiff-8q8q`; sequenced in
@@ -635,7 +657,7 @@ Non-obvious choices, each grounded in a principle:
 - flowmark v0.7.1 API: `flowmark.atomic_spans` (`iter_atomic_spans`,
   `split_sentences_with_spans`, named `AtomicSpan`s) and `flowmark.markdown_ast`
   (`block_span`, `walk_elements`, `extract_links`, `Link`).
-- Source: `src/chopdiff/docs/text_doc.py`, `block_tree.py`, `block_types.py`.
+- Source: `src/flexdoc/docs/text_doc.py`, `block_tree.py`, `block_types.py`, `block_info.py`.
 
 * * *
 

--- a/docs/textdoc-spec.md
+++ b/docs/textdoc-spec.md
@@ -1,11 +1,10 @@
 # TextDoc and DocGraph: Design Specification
 
-**Status:** Definitive front-to-back design of the document model — the `TextDoc`
-Python core and the `DocGraph` serialized projection — now housed in the `flexdoc`
-package (extracted from chopdiff; built in this repo, see §14).
+**Status:** Definitive front-to-back design of the document model (the `flexdoc`
+package): the `TextDoc` Python core and the `DocGraph` serialized projection.
 The design is settled (decision records DR-1..DR-6 in
 [`plan-2026-05-29-unified-document-model.md`](project/specs/active/plan-2026-05-29-unified-document-model.md));
-see §14 for what is implemented (v0.3.1) versus in progress.
+see §14 for what is implemented versus in progress.
 Dated plans under `docs/project/specs/` describe the incremental work toward this
 design.
 
@@ -448,8 +447,6 @@ doc.collect(within=section_id, kinds={NodeKind.link})      # links in a section
 Slice-by-block-type, per-section rollups, and element rollups are all expressions of
 this one primitive; relationships are node edges.
 There are no `tables()`/`code_blocks()` shortcuts to maintain.
-(The v0.3.1 `block_type_counts()` convenience accessors have since been **removed**; use
-`collect()` or `Counter(b.type for b in doc.blocks())`. See §14.)
 
 **Query vs. partition; do not conflate.** `collect()` is a *query*: it gathers matching
 nodes and the results may **overlap** their containers (a table nested in a blockquote
@@ -618,25 +615,18 @@ Non-obvious choices, each grounded in a principle:
 
 ## 14. Implementation Status
 
-- **Shipped in v0.3.1 (block-aware layer):** exact spans; the opt-in structural block
-  tree `blocks()` (boundaries and spans from flowmark, no regex scanner);
-  sections/TOC/size rollups; inline-link rollups and link-aware sentences;
-  `ordered_list`/density-invariant lists; and per-section blocks. (v0.3.1 also shipped
-  top-level `block_type_counts()`, since **removed** — see the unreleased changes below.)
-- **Also in v0.3.1 (DocGraph layer):** the recursive node table (containers fully populate
-  children, including blockquote and list-item block children); `base_blocks()`
+- **Implemented (block-aware layer):** exact spans; the opt-in structural block tree
+  `blocks()` (boundaries and spans from flowmark, no regex scanner); sections/TOC/size
+  rollups; inline-link rollups and link-aware sentences; `ordered_list`/density-invariant
+  lists; per-section blocks; and typed per-block metadata
+  (`CodeInfo`/`TableInfo`/`ListInfo`, §5).
+- **Implemented (DocGraph layer):** the recursive node table (containers fully populate
+  children, including blockquote and list-item block children); the `base_blocks()`
   sequential partition with its non-overlapping cover invariant; the single `collect()`
-  primitive; composable `include` layers and `detail` payload options; the `DocGraph`
-  Pydantic schema ("DocGraph/v0.1"); and the `SpanRef` contract with exact + prefix/suffix
-  quote resolution (fuzzy re-anchoring deferred).
-- **Unreleased (post-v0.3.1):** the document model was **extracted into the `flexdoc`
-  package** (`flexdoc.docs`/`html`/`util`; `chopdiff` keeps the diff/transform layer and
-  builds on `flexdoc` — one wheel, two import roots for now). Added: **typed per-block
-  metadata** — `CodeInfo` (`language`, `line_count`), `TableInfo` (`rows`, `cols`,
-  `cells`, `alignments`), `ListInfo` (`ordered`, `start`, `max_depth`, `item_count`) — on
-  `Block`/`Paragraph` and flattened into markdown node `attrs` (§5); the
-  **`footnote_ref`** inline kind (§8); and a `read_time` util. **Removed:**
-  `block_type_counts()` (use `collect()` / `Counter(b.type for b in doc.blocks())`).
+  query primitive; composable `include` layers and `detail` payload options; inline kinds
+  including `footnote_ref` (§8); the `DocGraph` Pydantic schema ("DocGraph/v0.1"); and the
+  `SpanRef` contract with exact + prefix/suffix quote resolution (fuzzy re-anchoring
+  deferred).
 - **In progress:** annotation layer, synthetic layer (re-expressing `TextNode` tag
   chunking as a layer), cross-layer structural edits, and operation/provenance/layout
   layers. Tracked by epic `chopdiff-8q8q`; sequenced in
@@ -652,7 +642,7 @@ Non-obvious choices, each grounded in a principle:
   [`research-2026-05-30-span-references.md`](project/research/research-2026-05-30-span-references.md),
   and the layered-parsing brief
   [`research-2026-05-30-multilayer-parsing.md`](project/research/research-2026-05-30-multilayer-parsing.md).
-- Completed block-aware plan (shipping in v0.3.1):
+- Completed block-aware plan:
   [`plan-2026-05-26-block-aware-doc.md`](project/specs/archive/plan-2026-05-26-block-aware-doc.md).
 - flowmark v0.7.1 API: `flowmark.atomic_spans` (`iter_atomic_spans`,
   `split_sentences_with_spans`, named `AtomicSpan`s) and `flowmark.markdown_ast`

--- a/src/flexdoc/docs/token_diffs.py
+++ b/src/flexdoc/docs/token_diffs.py
@@ -332,7 +332,7 @@ def find_best_alignment(
     prev_score = float("-inf")
 
     # Slide the second list over the first list, starting from the end of the first list.
-    # TODO: This could be much more efficient by being cleverer about reusing diff calculations.s
+    # TODO: This could be much more efficient by being cleverer about reusing diff calculations.
     for overlap in range(min_overlap, max_overlap + 1):
         start1 = len1 - overlap
         end1 = len1

--- a/tests/golden/README.md
+++ b/tests/golden/README.md
@@ -17,7 +17,7 @@ expected/<doc>/docgraph.yaml    the DocGraph projection as clean YAML
 expected/<doc>/reassembled.md   the editing view's reassembled (normalized) text
 ```
 
-The serializer is the public, reusable `chopdiff.docs.debug` dumper (`doc_report`,
+The serializer is the public, reusable `flexdoc.docs.debug` dumper (`doc_report`,
 `doc_graph_yaml`, `dump_views`) — usable on any document from a REPL or script, not just
 here.
 


### PR DESCRIPTION
## Summary

The "finish the easy cleanups" PR after the FlexDoc Stage-1 extraction merged. All low-risk and testable: `make lint` clean, **323 tests pass**, and the new wheel smoke test passes (validated locally). No behavior changes to the library.

### Design-of-record + reference sync
- **`textdoc-spec.md`**: the model now lives in `flexdoc`; `block_type_counts()` marked **removed** (not just "superseded"); documents the typed `CodeInfo`/`TableInfo`/`ListInfo` surface (§5) and `NodeKind.footnote_ref` (§8); §14 status refreshed; two stale `src/chopdiff` paths fixed.
- **`TODO.md`**: v0.3.1 is released; records the flexdoc extraction, typed metadata, `footnote_ref`, `read_time`; reconciles "Known Gaps" (`parse_tag`, root-level API, and the `collect()` `scope=`/`contains=` aliases now explicitly deferred to FlexDoc Stage 3).
- Stale `chopdiff.docs.debug → flexdoc.docs.debug` refs (TODO, golden README, golden-doc-testing spec); README logger names `chopdiff.docs → chopdiff.transforms`; a `.s` typo in a `token_diffs.py` comment.

### CI
- **`wheel-smoke` job**: builds the single `chopdiff` wheel, installs it isolated, and imports **both** `flexdoc` and `chopdiff` — guards the two-import-root packaging. Closes the "no wheel install/import smoke test" gap.

### FlexDoc Stage-2 handoff runbook
- `plan-2026-06-11-flexdoc-extraction.md` Stage 2 is now an **executable new-repo runbook**: exact copy list (package, tests, examples, design history), the external-dependency partition (`flexdoc`'s subset + `simplemma` extra; `chopdiff` keeps only `flexdoc`+`flowmark`+`prettyfmt`), new-repo scaffolding to mirror, the chopdiff-side rewiring (the breaking release), and standalone/rewired verification — so a fresh agent can run it in a new repo.

## Deliberately NOT in this PR
- **Frontmatter isolation (#22)** — the next PR (it reworks `from_text`'s span model; real regression surface, not an "easy cleanup").
- **`parse_tag` hardening** and **`collect()` alias removal** — both change documented/public surface; deferred to FlexDoc Stage 3 (settling the public API).
- CHANGELOG historical entries left as authored (no rewriting old release notes to new paths).

Draft pending your review.

https://claude.ai/code/session_01SKeHxxx8Q4P22y7fudBWiL

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKeHxxx8Q4P22y7fudBWiL)_