### PR TITLE
Frontmatter isolation in TextDoc.from_text (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ changes bump the **minor** version (see `docs/publishing.md`).
   footnote reference was silently dropped from the node table.
 - **`flexdoc.util.read_time.format_read_time(...)`.** Human-readable reading-time estimate
   from a word count (built on `prettyfmt.fmt_timedelta`).
+- **`TextDoc.frontmatter`.** A leading YAML frontmatter block (`---`-delimited) is now
+  isolated as a non-content region: excluded from `paragraphs`, `blocks()`, `sections()`,
+  the node table, `base_blocks()`, and all size/prose counts, and exposed verbatim via
+  `TextDoc.frontmatter` (or `None`). `source_text` keeps the full original and spans stay
+  absolute; frontmatter-free documents are unchanged.
 
 ## v0.3.1
 

--- a/docs/project/specs/active/plan-2026-06-11-frontmatter-isolation.md
+++ b/docs/project/specs/active/plan-2026-06-11-frontmatter-isolation.md
@@ -4,7 +4,7 @@
 
 **Author:** Joshua Levy
 
-**Status:** Approved
+**Status:** Implemented
 
 ## Overview
 
@@ -81,13 +81,13 @@ One phase, two implementation steps (editing view, then structural views), then 
 
 ### Phase 1: Frontmatter isolation
 
-- [ ] `split_frontmatter` detector + inline tests (with/without frontmatter, body-immediately,
+- [x] `split_frontmatter` detector + inline tests (with/without frontmatter, body-immediately,
       CRLF, a `---` thematic break that is *not* frontmatter).
-- [ ] `from_text` isolates the block; `TextDoc.frontmatter` + `_content_offset()`; paragraphs
+- [x] `from_text` isolates the block; `TextDoc.frontmatter` + `_content_offset()`; paragraphs
       built over the body with shifted absolute offsets.
-- [ ] Filter the frontmatter region from `_block_list()`, `base_blocks()`, and the node
+- [x] Filter the frontmatter region from `_block_list()`, `base_blocks()`, and the node
       table's inline/link pass.
-- [ ] Tests + `docs/textdoc-spec.md` §8/§3 note and `CHANGELOG.md` (additive).
+- [x] Tests + `docs/textdoc-spec.md` §8/§3 note and `CHANGELOG.md` (additive).
 
 ## Testing Strategy
 

--- a/docs/project/specs/active/plan-2026-06-11-frontmatter-isolation.md
+++ b/docs/project/specs/active/plan-2026-06-11-frontmatter-isolation.md
@@ -1,0 +1,123 @@
+# Feature: TextDoc Frontmatter Isolation (#22)
+
+**Date:** 2026-06-11 (last updated 2026-06-11)
+
+**Author:** Joshua Levy
+
+**Status:** Approved
+
+## Overview
+
+`TextDoc.from_text` currently treats a leading YAML frontmatter block (`---\n…\n---`) as
+ordinary content, so it leaks into `paragraphs`, the structural views, the node table, and
+every prose/size count. This feature recognizes frontmatter as a first-class **non-content
+region**: it is excluded from every view and count, exposed verbatim via
+`TextDoc.frontmatter`, while `source_text` keeps the full original and all spans stay
+absolute. This is the last open item of issues #18–#22 (the markdown-layer completion).
+
+## Goals
+
+- A leading YAML frontmatter block is excluded from `paragraphs`/`sentences`, `blocks()`,
+  `sections()`, the node table, `base_blocks()`, and all `size(...)` counts.
+- `TextDoc.frontmatter -> str | None` returns the verbatim block (delimiters included), or
+  `None` when absent.
+- `source_text` retains the full original (round-trips); spans stay absolute, so
+  `source_text[unit.span[0]:unit.span[1]] == unit.original_text` still holds.
+- The body parses to the same structure as if the frontmatter were absent.
+- The no-frontmatter path is byte-for-byte unchanged.
+
+## Non-Goals
+
+- No parsed-frontmatter API (a metadata `dict`) and no document-layer frontmatter *node* in
+  v1 — the raw block plus exclusion is the floor, with a clean additive path to both later.
+- Only YAML `---` frontmatter (the `FmStyle.yaml` delimiters). HTML/code frontmatter styles
+  are out of scope for v1.
+
+## Background
+
+`frontmatter-format` (already a dependency) is **file-based** — every `fmf_*` function takes
+a `pathlib.Path`, so it cannot parse an in-memory string and is unusable in the
+`from_text(str)` hot path. flexdoc therefore detects the block itself at the string level,
+matching `FmStyle.yaml` delimiters (opening `---` line, closing `---` line). This also keeps
+file I/O out of parsing.
+
+The structural views all derive from the full `source_text`: `_parsed()` parses it,
+`_block_list()` is `parse_blocks(source_text, _parsed())`, `base_blocks()` and the node
+table's inline pass (`iter_atomic_spans(source_text)`) scan it. Because the frontmatter is
+delimited by `---` lines, marko parses it into blocks entirely within the leading region and
+the body blocks are unaffected (a `---` line is a thematic break / setext rule, never a
+container that swallows the body). So the lowest-risk design is **filter the frontmatter
+region out of the views** rather than reparse the body and thread an offset through the span
+model: spans stay absolute straight from the full parse, and exclusion is a single
+`span >= content_offset` guard at each view boundary, regardless of how marko interprets the
+frontmatter text.
+
+## Design
+
+### Approach
+
+Detect the block once from `source_text`; build the editing view over the body; filter the
+frontmatter region out of the structural views. `frontmatter` and the body offset are pure
+derivations of the immutable `source_text` (no new stored state, so copy/pickle are
+unchanged).
+
+### Components
+
+| Area | Change |
+| --- | --- |
+| Detection | `flexdoc.docs.frontmatter.split_frontmatter(text) -> tuple[str | None, int]` (new): returns `(raw_block_or_None, content_offset)` where `text[content_offset:]` is the body. Pure, stdlib-only, with inline tests. |
+| `TextDoc` derivations | `frontmatter` and `_content_offset()` memoized derivations over `source_text` (= `split_frontmatter(source_text)`). |
+| Editing view | `from_text` splits the **body** (`text[content_offset:]`) on blank lines, shifting each paragraph's `doc_offset` by `content_offset` (absolute spans); `source_text` stays the full `text`. Paragraphs/sentences/`size` then exclude frontmatter for free. |
+| Structural views | `_block_list()` drops top-level blocks with `span[0] < content_offset`; `TextDoc.base_blocks()` drops base blocks in the region; `node_table._build_inline_nodes` skips links/atomics starting before `content_offset`. `sections()` and markdown nodes derive from `blocks()`, so they follow automatically. |
+
+### API Changes
+
+- **Added:** `TextDoc.frontmatter -> str | None`; `flexdoc.docs.frontmatter.split_frontmatter`.
+- No signature changes elsewhere; all exclusions are internal.
+
+## Implementation Plan
+
+One phase, two implementation steps (editing view, then structural views), then docs.
+
+### Phase 1: Frontmatter isolation
+
+- [ ] `split_frontmatter` detector + inline tests (with/without frontmatter, body-immediately,
+      CRLF, a `---` thematic break that is *not* frontmatter).
+- [ ] `from_text` isolates the block; `TextDoc.frontmatter` + `_content_offset()`; paragraphs
+      built over the body with shifted absolute offsets.
+- [ ] Filter the frontmatter region from `_block_list()`, `base_blocks()`, and the node
+      table's inline/link pass.
+- [ ] Tests + `docs/textdoc-spec.md` §8/§3 note and `CHANGELOG.md` (additive).
+
+## Testing Strategy
+
+- Detector unit tests (inline): frontmatter present/absent, body immediately after the close,
+  CRLF, and a leading `---` thematic break (no closing `---`) that must **not** be treated as
+  frontmatter.
+- A document with frontmatter: excluded from `paragraphs`, `blocks()`, `sections()`,
+  `node_table()`, `base_blocks()`, and `size(...)`; `frontmatter` returns the verbatim block;
+  the span/round-trip invariant holds.
+- **Body-equivalence:** `blocks()`/`sections()` of `frontmatter + body` equal those of `body`
+  alone (modulo the absolute offset), proving the frontmatter does not perturb the body parse.
+- No-frontmatter path unchanged (`frontmatter is None`; identical paragraphs/blocks/counts).
+
+## Rollout Plan
+
+Additive and behavior-preserving for frontmatter-free documents, so a normal additive release
+(`TextDoc.frontmatter` is new surface). Note it in `CHANGELOG.md` under Unreleased.
+
+## Open Questions
+
+- Parsed-frontmatter `dict` (`fmf`-style) and a first-class document-layer frontmatter node
+  are natural additive follow-ups; deferred to keep v1 the minimal floor.
+
+## References
+
+- Issue [#22](https://github.com/jlevy/chopdiff/issues/22).
+- Markdown-layer plan (origin of #18–#22):
+  [`plan-2026-06-11-structural-metadata.md`](plan-2026-06-11-structural-metadata.md).
+- Design of record: [`docs/textdoc-spec.md`](../../../textdoc-spec.md).
+
+<!-- This document follows common-doc-guidelines.md.
+See github.com/jlevy/practical-prose and review guidelines before editing.
+-->

--- a/docs/project/specs/active/plan-2026-06-11-structural-metadata.md
+++ b/docs/project/specs/active/plan-2026-06-11-structural-metadata.md
@@ -4,7 +4,7 @@
 
 **Author:** Joshua Levy
 
-**Status:** Partially implemented (additive surface landed; see Implementation Status).
+**Status:** Implemented (all of #18–#22 landed across three PRs; see Implementation Status).
 
 > **Implementation Status (2026-06-11).** Landed on branch `claude/eager-hawking-nyy2zz`
 > (atop the FlexDoc Stage-1 extraction, so the files below now live under `src/flexdoc/`,
@@ -21,10 +21,11 @@
 > - ✔︎ **`read_time.py` salvage.** `flexdoc/util/read_time.py` (`format_read_time`, with its
 >   inline tests) recovered from the abandoned branch and exported from `flexdoc.util`;
 >   depends only on `prettyfmt.fmt_timedelta` (already available).
-> - ‼︎ **Deferred for review** (not yet implemented): the frontmatter isolation (#22; reworks
->   `from_text`'s span model, higher regression risk) and the `docs/textdoc-spec.md` /
->   `TODO.md` updates. Checkboxes below are unchanged; this banner is the source of truth for
->   what landed.
+> - ✔︎ **Frontmatter isolation (#22).** Landed in its own PR
+>   ([`plan-2026-06-11-frontmatter-isolation.md`](plan-2026-06-11-frontmatter-isolation.md)):
+>   `TextDoc.frontmatter` excludes a leading YAML block from all views/counts. This completes
+>   issues #18–#22. The `docs/textdoc-spec.md` / `TODO.md` updates also landed (post-extraction
+>   cleanup PR).
 
 ## Overview
 
@@ -244,47 +245,47 @@ Migration: `Counter(b.type for b in doc.blocks())`, or
 
 The bulk: #18 / #19 / #20, plus the two adjacent cleanups that share the release.
 
-- [ ] Add `block_info.py`: `CodeInfo` / `TableInfo` / `ListInfo` and the pure extractors,
+- [x] Add `block_info.py`: `CodeInfo` / `TableInfo` / `ListInfo` and the pure extractors,
   reading marko attributes (`FencedCode.lang`, `Table.num_of_cols` + cell `.align`,
   `List.ordered`/`.start`/subtree). Inline tests under a `## Tests` section for the
   extractors over fenced/indented code, ordered/unordered/nested lists, and tables with
   mixed alignments.
-- [ ] Carry the info on `Block` (computed in `block_tree._blocks_from` where the element is in
+- [x] Carry the info on `Block` (computed in `block_tree._blocks_from` where the element is in
   hand) and expose `Block.code_info` / `.table_info` / `.list_info`.
-- [ ] Populate markdown-node `attrs` from the block info in
+- [x] Populate markdown-node `attrs` from the block info in
   `node_table._build_markdown_nodes` (additive keys; existing `tight`/`ordered` unchanged).
-- [ ] Reuse the extractors in `Paragraph._block_info`; add `Paragraph.code_info` /
+- [x] Reuse the extractors in `Paragraph._block_info`; add `Paragraph.code_info` /
   `.table_info` / `.list_info` with the density caveat in their docstrings.
 - [x] Remove `TextDoc.block_type_counts()` / `Section.block_type_counts()`; migrate internal
   callers/tests/examples to `collect()` / `blocks()`; record the migration in `CHANGELOG.md`.
 - [x] Salvage `src/chopdiff/util/read_time.py` (with its inline tests) from the abandoned
   branch; confirm its `prettyfmt.fmt_timedelta` dependency is already satisfied.
-- [ ] Update `docs/textdoc-spec.md` §5 (block-type model: per-kind typed `attrs`) and §9
+- [x] Update `docs/textdoc-spec.md` §5 (block-type model: per-kind typed `attrs`) and §9
   (note typed attrs are element attributes, not rollups; `block_type_counts()` removed);
   refresh the stale `TODO.md` status (v0.3.1 is released).
-- [ ] `make lint` and `make test` clean.
+- [x] `make lint` and `make test` clean.
 
 ### Phase 2: Inline + document-region completion
 
 Independent of Phase 1: #21 and #22.
 
 - [x] Add `NodeKind.footnote_ref` and include it in `collect.INLINE_KINDS`.
-- [ ] In `node_table._build_inline_nodes`, recognize footnote-reference atomics (a
+- [x] In `node_table._build_inline_nodes`, recognize footnote-reference atomics (a
   `markdown_link` atomic whose text starts `[^` and is not a `:`-suffixed definition); emit a
   `footnote_ref` node with exact span and `attrs={"label": ...}`. Add tests: a `[^1]`
   reference is collected via `collect(kinds={NodeKind.footnote_ref})` with the right span and
   label, and footnote *definitions* (`[^1]:`) are not mistaken for references.
-- [ ] In `TextDoc.from_text`, detect and isolate a leading YAML frontmatter block via
+- [x] In `TextDoc.from_text`, detect and isolate a leading YAML frontmatter block via
   `frontmatter-format`; store it; build `paragraphs` and the structural parse over the body
   (shifting spans by the content offset) so no paragraph/block/section/node originates inside
   the frontmatter region. Add `TextDoc.frontmatter`.
-- [ ] Tests: a document with frontmatter excludes it from `paragraphs`, `blocks()`,
+- [x] Tests: a document with frontmatter excludes it from `paragraphs`, `blocks()`,
   `sections()`, the node table, and `size(...)`; `frontmatter` returns the verbatim block;
   the span/round-trip invariant holds; a document without frontmatter is unchanged
   (`frontmatter is None`).
-- [ ] Update `docs/textdoc-spec.md` (inline kinds include `footnote_ref`; a short
+- [x] Update `docs/textdoc-spec.md` (inline kinds include `footnote_ref`; a short
   frontmatter note) and `CHANGELOG.md`.
-- [ ] `make lint` and `make test` clean.
+- [x] `make lint` and `make test` clean.
 
 ## Testing Strategy
 

--- a/docs/textdoc-spec.md
+++ b/docs/textdoc-spec.md
@@ -154,6 +154,11 @@ id and span — and is what the serialized contract and cross-layer queries are 
 3. **Language structure:** paragraphs, sentences, and the wordtok view, with spans and
    spacing tokens (the editing view).
 
+A leading YAML frontmatter block (`---`-delimited) is a **non-content region**: it is
+excluded from the node table, the block/section views, and the editing view (and so from
+every size/prose count), and exposed verbatim via `TextDoc.frontmatter`. `source_text`
+retains it, so spans stay absolute and the document still round-trips.
+
 Why a node table and not a single tree: a document has several hierarchies that overlap
 and do not nest: a **section** spans sibling blocks and is not a subtree of the block
 tree; **links** are inline ranges; **annotations** target arbitrary spans.

--- a/src/flexdoc/docs/frontmatter.py
+++ b/src/flexdoc/docs/frontmatter.py
@@ -1,0 +1,77 @@
+"""
+Detection of leading YAML frontmatter, at the string level.
+
+`frontmatter-format` (the library) is file-based — every `fmf_*` function takes a path —
+so it cannot parse an in-memory string and is unusable in `TextDoc.from_text(str)`. This
+module detects the leading `---`-delimited block itself, matching `frontmatter-format`'s
+`FmStyle.yaml` delimiters (an opening `---` line and a closing `---` line), without any
+file I/O.
+"""
+
+from __future__ import annotations
+
+_DELIM = "---"
+
+
+def split_frontmatter(text: str) -> tuple[str | None, int]:
+    """
+    Split a leading YAML frontmatter block from `text`.
+
+    Returns `(raw, content_offset)` where `raw` is the verbatim block — both delimiter
+    lines and the trailing newline included — or `None` when there is no frontmatter, and
+    `text[content_offset:]` is the body (`content_offset == 0` when absent).
+
+    Frontmatter must begin at offset 0 with a line that is exactly `---` and be closed by a
+    later line that is exactly `---`. A leading `---` with no matching closing line is an
+    ordinary thematic break, not frontmatter, and yields `(None, 0)`.
+    """
+    first_nl = text.find("\n")
+    if first_nl == -1:
+        return None, 0
+    # The opening line must be exactly the delimiter (tolerating a CR for CRLF input).
+    if text[:first_nl].rstrip("\r") != _DELIM:
+        return None, 0
+
+    pos = first_nl + 1
+    while pos <= len(text):
+        nl = text.find("\n", pos)
+        line_end = len(text) if nl == -1 else nl
+        if text[pos:line_end].rstrip("\r") == _DELIM:
+            content_offset = len(text) if nl == -1 else nl + 1
+            return text[:content_offset], content_offset
+        if nl == -1:
+            break
+        pos = nl + 1
+    return None, 0
+
+
+## Tests
+
+
+def test_split_frontmatter():
+    # Standard block, blank line before body.
+    raw, off = split_frontmatter("---\ntitle: Hello\ntags: [a, b]\n---\n\n# Body\n")
+    assert raw == "---\ntitle: Hello\ntags: [a, b]\n---\n"
+    assert off == len(raw)
+
+    # Body immediately after the close (no blank line).
+    raw, off = split_frontmatter("---\ntitle: x\n---\n# Body now\n")
+    assert raw == "---\ntitle: x\n---\n"
+    assert off == len("---\ntitle: x\n---\n")
+
+    # Empty frontmatter.
+    assert split_frontmatter("---\n---\nbody\n") == ("---\n---\n", 8)
+
+    # CRLF input.
+    raw, off = split_frontmatter("---\r\ntitle: x\r\n---\r\nbody\r\n")
+    assert raw == "---\r\ntitle: x\r\n---\r\n"
+    assert off == len(raw)
+
+    # No frontmatter.
+    assert split_frontmatter("# Heading\n\nBody.\n") == (None, 0)
+
+    # A leading thematic break with no closing delimiter is NOT frontmatter.
+    assert split_frontmatter("---\n\nJust a rule above.\n") == (None, 0)
+
+    # Must start at offset 0.
+    assert split_frontmatter("\n---\ntitle: x\n---\nbody\n") == (None, 0)

--- a/src/flexdoc/docs/node_table.py
+++ b/src/flexdoc/docs/node_table.py
@@ -145,11 +145,14 @@ def _build_inline_nodes(
     index = IntervalIndex.from_nodes(all_nodes)
 
     seen_spans: set[tuple[int, int]] = set()
+    # Frontmatter is a non-content region: skip any inline element located inside it (see
+    # TextDoc.frontmatter). Block/section/textual nodes are already frontmatter-free.
+    content_offset = doc._content_offset()
 
     # Links via doc.links() (handles reference resolution correctly).
     for link in doc.links():
         if link.span is not None:
-            if link.span in seen_spans:
+            if link.span[0] < content_offset or link.span in seen_spans:
                 continue
             seen_spans.add(link.span)
             nid = _next_id(counter)
@@ -199,6 +202,8 @@ def _build_inline_nodes(
         if not atomic.is_atomic or atomic.name is None:
             continue
         if atomic.name not in _INLINE_ATOMIC_KINDS:
+            continue
+        if atomic.start < content_offset:  # inside the frontmatter region
             continue
 
         span = (atomic.start, atomic.end)

--- a/src/flexdoc/docs/text_doc.py
+++ b/src/flexdoc/docs/text_doc.py
@@ -30,6 +30,7 @@ from flexdoc.docs.block_tree import Block, parse_blocks
 from flexdoc.docs.block_types import BlockType, block_type_for
 from flexdoc.docs.collect import collect as _collect
 from flexdoc.docs.doc_graph import _DEFAULT_INCLUDE, Detail, DocGraph, build_doc_graph
+from flexdoc.docs.frontmatter import split_frontmatter
 from flexdoc.docs.node import Layer, Node, NodeKind, NodeTable
 from flexdoc.docs.node_table import build_node_table
 from flexdoc.docs.sizes import TextUnit, size, size_in_bytes
@@ -664,21 +665,41 @@ class TextDoc:
         `p.original_text`. `reassemble()` produces normalized editable text, not a
         byte-for-byte copy of the full input.
         """
+        # A leading YAML frontmatter block is isolated as a non-content region: paragraphs
+        # (and thus sentences, sizes, and prose counts) are built over the body only, with
+        # absolute offsets into the full `text` (kept as `source_text`). See `frontmatter`.
+        _raw, content_offset = split_frontmatter(text)
+        body = text[content_offset:]
         paragraphs: list[Paragraph] = []
         spans: list[tuple[int, int]] = []
         start = 0
-        for m in _PARA_BREAK_REGEX.finditer(text):
+        for m in _PARA_BREAK_REGEX.finditer(body):
             spans.append((start, m.start()))
             start = m.end()
-        spans.append((start, len(text)))
+        spans.append((start, len(body)))
         for span_start, span_end in spans:
-            piece = text[span_start:span_end]
+            piece = body[span_start:span_end]
             stripped = piece.strip()
             if stripped:
-                # Doc offset of the stripped content within the original text.
-                doc_offset = span_start + (len(piece) - len(piece.lstrip()))
+                # Doc offset of the stripped content within the original text (absolute).
+                doc_offset = content_offset + span_start + (len(piece) - len(piece.lstrip()))
                 paragraphs.append(Paragraph.from_text(stripped, doc_offset, sentence_splitter))
         return cls(paragraphs=paragraphs, source_text=text)
+
+    @property
+    def frontmatter(self) -> str | None:
+        """
+        The verbatim leading YAML frontmatter block (both `---` delimiters included), or
+        `None` if the document has none. Frontmatter is a non-content region: excluded from
+        `paragraphs`, `blocks()`, `sections()`, the node table, and every size/prose count,
+        but `source_text` retains it so the document round-trips.
+        """
+        return split_frontmatter(self.source_text)[0]
+
+    def _content_offset(self) -> int:
+        """Offset into `source_text` where the body (post-frontmatter content) begins;
+        0 when there is no frontmatter."""
+        return split_frontmatter(self.source_text)[1]
 
     @classmethod
     def from_wordtoks(cls, wordtoks: list[str]) -> TextDoc:

--- a/src/flexdoc/docs/text_doc.py
+++ b/src/flexdoc/docs/text_doc.py
@@ -825,7 +825,14 @@ class TextDoc:
 
     @_memoized_derivation("_cached_blocks")
     def _block_list(self) -> list[Block]:
-        return parse_blocks(self.source_text or self.reassemble(), self._parsed())
+        blocks = parse_blocks(self.source_text or self.reassemble(), self._parsed())
+        # Exclude any block in the leading frontmatter region (a non-content region; see
+        # `frontmatter`). Frontmatter parses into top-level blocks before the body, so a
+        # span-start guard drops them without disturbing the body's absolute spans.
+        content_offset = self._content_offset()
+        if content_offset:
+            blocks = [b for b in blocks if b.span[0] >= content_offset]
+        return blocks
 
     def blocks(self) -> list[Block]:
         """
@@ -852,11 +859,17 @@ class TextDoc:
         recursive structural tree (a query view, not a partition). Reuses the document's
         single shared parse.
         """
-        return base_blocks(
+        partition = base_blocks(
             self.source_text or self.reassemble(),
             item_partition_depth=item_partition_depth,
             parsed=self._parsed(),
         )
+        # Drop the leading frontmatter region (see `frontmatter`); it is not content, so it
+        # is not part of the document's base-block partition.
+        content_offset = self._content_offset()
+        if content_offset:
+            partition = [bb for bb in partition if bb.block.span[0] >= content_offset]
+        return partition
 
     def toc(self) -> list[tuple[int, str, tuple[int, int]]]:
         """Flat table of contents in document order: `(level, title, span)` per heading."""

--- a/tests/docs/test_frontmatter.py
+++ b/tests/docs/test_frontmatter.py
@@ -1,0 +1,54 @@
+"""
+Frontmatter isolation (editing view): a leading YAML block is a non-content region —
+excluded from paragraphs/sentences/size and exposed verbatim via `TextDoc.frontmatter`,
+while `source_text` keeps the full original and spans stay absolute. Detector unit tests
+live inline in `flexdoc.docs.frontmatter`; structural-view exclusion is tested separately.
+"""
+
+from __future__ import annotations
+
+from textwrap import dedent
+
+from flexdoc.docs.sizes import TextUnit
+from flexdoc.docs.text_doc import TextDoc
+
+_FM = "---\ntitle: Hello\ntags: [a, b]\n---\n\n"
+_BODY = (
+    dedent("""
+    # Heading
+
+    First paragraph with some words.
+
+    Second paragraph here.
+    """).strip()
+    + "\n"
+)
+
+
+def test_frontmatter_property_and_paragraph_exclusion():
+    doc = TextDoc.from_text(_FM + _BODY)
+    assert doc.frontmatter == "---\ntitle: Hello\ntags: [a, b]\n---\n"
+    assert doc.source_text == _FM + _BODY  # full original retained
+    content_offset = len(_FM)
+    assert all(p.span[0] >= content_offset for p in doc.paragraphs)
+    assert all("title: Hello" not in p.original_text for p in doc.paragraphs)
+
+
+def test_frontmatter_excluded_from_size():
+    with_fm = TextDoc.from_text(_FM + _BODY)
+    body_only = TextDoc.from_text(_BODY)
+    for unit in (TextUnit.words, TextUnit.wordtoks):
+        assert with_fm.size(unit) == body_only.size(unit)
+
+
+def test_span_roundtrip_invariant_holds_with_frontmatter():
+    doc = TextDoc.from_text(_FM + _BODY)
+    for p in doc.paragraphs:
+        assert doc.source_text[p.span[0] : p.span[1]] == p.original_text
+
+
+def test_thematic_break_is_not_frontmatter():
+    # A leading `---` with no closing delimiter is a thematic break, not frontmatter.
+    doc = TextDoc.from_text("---\n\n# Real Heading\n\nBody.\n")
+    assert doc.frontmatter is None
+    assert doc.source_text == "---\n\n# Real Heading\n\nBody.\n"

--- a/tests/docs/test_frontmatter.py
+++ b/tests/docs/test_frontmatter.py
@@ -52,3 +52,28 @@ def test_thematic_break_is_not_frontmatter():
     doc = TextDoc.from_text("---\n\n# Real Heading\n\nBody.\n")
     assert doc.frontmatter is None
     assert doc.source_text == "---\n\n# Real Heading\n\nBody.\n"
+
+
+def test_frontmatter_excluded_from_structural_views():
+    doc = TextDoc.from_text(_FM + _BODY)
+    co = len(_FM)
+    assert doc.blocks() and all(b.span[0] >= co for b in doc.blocks())
+    assert doc.sections() and all(s.span[0] >= co for s in doc.sections())
+    assert all(bb.block.span[0] >= co for bb in doc.base_blocks())
+    table = doc.node_table()
+    assert all(n.source_span is None or n.source_span[0] >= co for n in table.nodes.values())
+
+
+def test_yaml_frontmatter_is_not_a_section():
+    # `title: Hello\n---` can parse as a setext H2; it must not become a document section.
+    doc = TextDoc.from_text(_FM + _BODY)
+    assert [s.title for s in doc.sections()] == ["Heading"]
+
+
+def test_body_blocks_unperturbed_by_frontmatter():
+    co = len(_FM)
+    with_fm = TextDoc.from_text(_FM + _BODY).blocks()
+    body_only = TextDoc.from_text(_BODY).blocks()
+    assert [b.type for b in with_fm] == [b.type for b in body_only]
+    # Same structure, spans shifted by exactly the frontmatter length.
+    assert [b.span for b in with_fm] == [(s + co, e + co) for s, e in (b.span for b in body_only)]


### PR DESCRIPTION
## Summary

Frontmatter isolation — the last open item of issues #18–#22 (markdown-layer completion). Mapped with `tbd` (epic `chopdiff-u42f`, beads `lc9n → gpxl → i1qg`, spec-linked) and implemented bead-by-bead. `make lint` clean, **331 tests pass**.

A leading YAML frontmatter block (`---`-delimited) is now a first-class **non-content region**: excluded from `paragraphs`, `blocks()`, `sections()`, the node table, `base_blocks()`, and all size/prose counts, and exposed verbatim via **`TextDoc.frontmatter`** (`str | None`). `source_text` keeps the full original and spans stay absolute.

### Design notes
- **`frontmatter-format` is file-based** (every `fmf_*` takes a path), so it can't parse the `from_text(str)` hot path. flexdoc detects the `---`-delimited block itself at the string level (`flexdoc.docs.frontmatter.split_frontmatter`), which also keeps file I/O out of parsing.
- **Filter-the-region, not reparse-the-body.** Since the frontmatter parses into top-level blocks before the body (a `---` line is a thematic break / setext rule, never a container), exclusion is a single `span >= content_offset` guard at each view boundary — spans stay absolute straight from the full parse, with no offset threading through the span model. Lower regression surface.
- **No-frontmatter documents are byte-for-byte unchanged** (`content_offset == 0` skips every guard).

### Beads
1. `lc9n` — `split_frontmatter` detector + `from_text` isolation + `TextDoc.frontmatter` + editing-view exclusion.
2. `gpxl` — structural-view exclusion (`blocks`/`base_blocks`/node table; sections + markdown nodes follow).
3. `i1qg` — docs (textdoc-spec normalized-form note, CHANGELOG) + close out #18–#22.

### Tests
Detector unit tests (present/absent, body-immediately, CRLF, a leading `---` thematic break that is *not* frontmatter); exclusion across every view + size; the span/round-trip invariant; **body-equivalence** (body blocks equal the no-frontmatter parse shifted by the frontmatter length); YAML never becomes a section.

Spec: `docs/project/specs/active/plan-2026-06-11-frontmatter-isolation.md`.

Closes #22.

Draft pending your review.

https://claude.ai/code/session_01SKeHxxx8Q4P22y7fudBWiL

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKeHxxx8Q4P22y7fudBWiL)_